### PR TITLE
Add reusable version-bump, version-check, unit-tests, and version-set workflows

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,50 @@
+name: Unit Tests (Callable)
+
+on:
+  workflow_call:
+    secrets:
+      PLUGIN_CI_APP_ID:
+        description: "GitHub App ID for private dependency access (contents:read)"
+        required: true
+      PLUGIN_CI_PRIVATE_KEY:
+        description: "GitHub App private key for private dependency access"
+        required: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Generate token for private dependencies
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PLUGIN_CI_APP_ID }}
+          private-key: ${{ secrets.PLUGIN_CI_PRIVATE_KEY }}
+          owner: praetorian-inc
+          repositories: claude-tool-sdk
+
+      - name: Configure git for private dependencies
+        run: |
+          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "git@github.com:"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-audit --no-fund
+          fi
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,89 @@
+name: Version Bump (Callable)
+
+on:
+  workflow_call:
+    secrets:
+      VERSION_BUMPER_APP_ID:
+        description: "GitHub App ID for praetorian-ci-version-bumper"
+        required: true
+      VERSION_BUMPER_PRIVATE_KEY:
+        description: "GitHub App private key for praetorian-ci-version-bumper"
+        required: true
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    # Only run on PR open or when 'bump' label is added
+    if: >-
+      github.event.action == 'opened' ||
+      (github.event.action == 'labeled' &&
+       github.event.label.name == 'bump')
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
+          private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Determine bump level from branch name
+        id: bump
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          if [[ "$BRANCH" == release/* ]]; then
+            BUMP="major"
+          elif [[ "$BRANCH" == feat/* || "$BRANCH" == feature/* ]]; then
+            BUMP="minor"
+          else
+            BUMP="patch"
+          fi
+          echo "level=$BUMP" >> "$GITHUB_OUTPUT"
+          echo "Bump level: $BUMP (branch: $BRANCH)"
+
+      - name: Bump version
+        id: version
+        run: |
+          CURRENT=$(git show origin/main:.claude-plugin/plugin.json | jq -r '.version')
+          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
+
+          case "${{ steps.bump.outputs.level }}" in
+            major)
+              NEW_VERSION="$((MAJOR + 1)).0.0"
+              ;;
+            minor)
+              NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
+              ;;
+            patch)
+              NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+              ;;
+          esac
+
+          echo "New version: $NEW_VERSION (was $CURRENT, bump: ${{ steps.bump.outputs.level }})"
+          jq --arg v "$NEW_VERSION" '.version = $v' .claude-plugin/plugin.json > tmp.json && mv tmp.json .claude-plugin/plugin.json
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push to PR branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
+          git push origin HEAD:${{ github.head_ref }}
+
+      - name: Remove bump label
+        if: github.event.action == 'labeled'
+        run: gh pr edit ${{ github.event.number }} --remove-label bump
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,25 @@
+name: Version Check (Callable)
+
+on:
+  workflow_call: {}
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version was bumped
+        run: |
+          BASE_VERSION=$(git show origin/main:.claude-plugin/plugin.json | jq -r '.version')
+          PR_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+
+          if [ "$BASE_VERSION" = "$PR_VERSION" ]; then
+            echo "::error::plugin.json version not bumped (still $PR_VERSION)."
+            echo "::error::The auto-bump may have failed. Add the 'bump' label to retry."
+            exit 1
+          fi
+
+          echo "Version bumped: $BASE_VERSION -> $PR_VERSION"

--- a/.github/workflows/version-set.yml
+++ b/.github/workflows/version-set.yml
@@ -1,0 +1,75 @@
+name: Set Version (Callable)
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version number in semver format (e.g. 2.1.4)"
+        required: true
+        type: string
+      create_release:
+        description: "Create a GitHub release after tagging"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      VERSION_BUMPER_APP_ID:
+        description: "GitHub App ID for praetorian-ci-version-bumper"
+        required: true
+      VERSION_BUMPER_PRIVATE_KEY:
+        description: "GitHub App private key for praetorian-ci-version-bumper"
+        required: true
+
+jobs:
+  set-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: Version must be in semver format (e.g. 2.1.4)"
+            exit 1
+          fi
+
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
+          private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set version
+        env:
+          NEW_VERSION: ${{ inputs.version }}
+        run: |
+          echo "Setting version to: $NEW_VERSION"
+          jq --arg v "$NEW_VERSION" '.version = $v' .claude-plugin/plugin.json > tmp.json && mv tmp.json .claude-plugin/plugin.json
+          echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json
+          git commit -m "chore: set version to v${NEW_VERSION} [skip ci]"
+          git tag "v${NEW_VERSION}"
+          git push origin main --tags
+
+      - name: Create GitHub release
+        if: ${{ inputs.create_release }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${NEW_VERSION}" \
+            --title "v${NEW_VERSION}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- Add 4 reusable `workflow_call` workflows following the claude-code.yml pattern
- **version-bump**: uses dedicated GitHub App token for push (triggers CI re-runs instead of silent GITHUB_TOKEN pushes)
- **version-check**: pure read-only version comparison (no secrets needed)
- **unit-tests**: private dependency support via read-only GitHub App (handles both npm ci and npm install)
- **version-set**: manual version override with optional GitHub release creation
- Replaces 47 duplicated workflow files across 18 plugin repos with thin callers

## Workflows Added
| Workflow | Purpose | Secrets |
|----------|---------|---------|
| `version-bump.yml` | Auto-bump version on PR open/label | `VERSION_BUMPER_APP_ID`, `VERSION_BUMPER_PRIVATE_KEY` |
| `version-check.yml` | Verify version was bumped vs main | None |
| `unit-tests.yml` | Run npm tests with private dep access | `PLUGIN_CI_APP_ID`, `PLUGIN_CI_PRIVATE_KEY` |
| `version-set.yml` | Manual version set + tag + optional release | `VERSION_BUMPER_APP_ID`, `VERSION_BUMPER_PRIVATE_KEY` |

## Test plan
- [ ] Verify workflows appear in public-workflows Actions tab
- [ ] Test caller from praetorian-core first (Phase 2 canary)
- [ ] Roll out to remaining 17 repos after canary passes