### PR TITLE
feat: add centralized go-ci.yml reusable workflow (ENG-3092)

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,254 @@
+name: Go CI (Callable)
+# Reusable workflow for Go repositories in the praetorian-inc org.
+# Consumers call this workflow to get consistent lint + test + build + runtime hardening
+# without duplicating inline CI jobs per repo.
+#
+# Access: this workflow is invocable from any repo in the praetorian-inc org
+# (Settings -> Actions -> General -> Access -> Accessible from repositories in
+# the 'praetorian-inc' organization).
+#
+# Caller example:
+#   jobs:
+#     ci:
+#       uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@<SHA>  # v1.0.0
+#       permissions:
+#         contents: read
+#       with:
+#         golangci-lint-version: v2.11.4
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: "Working directory for the Go module (useful for multi-module repos)."
+        required: false
+        type: string
+        default: "."
+
+      go-version-file:
+        description: "Path to go.mod (relative to working-directory) used as Go version source of truth."
+        required: false
+        type: string
+        default: "go.mod"
+
+      enable-lint:
+        description: "Whether to run golangci-lint. Set false for repos without a golangci config."
+        required: false
+        type: boolean
+        default: true
+
+      golangci-lint-version:
+        description: "Pinned golangci-lint binary version. Use a specific version; never 'latest'."
+        required: false
+        type: string
+        default: "v2.11.4"
+
+      golangci-lint-timeout:
+        description: "Timeout for golangci-lint run."
+        required: false
+        type: string
+        default: "5m"
+
+      enable-test:
+        description: "Whether to run go test."
+        required: false
+        type: boolean
+        default: true
+
+      test-flags:
+        description: "Flags passed to 'go test'. Defaults include race detector and coverage."
+        required: false
+        type: string
+        default: "-race -coverprofile=coverage.out -covermode=atomic"
+
+      test-packages:
+        description: "Package selector passed to 'go test'."
+        required: false
+        type: string
+        default: "./..."
+
+      enable-build:
+        description: "Whether to run the cross-platform build matrix."
+        required: false
+        type: boolean
+        default: true
+
+      build-matrix-os:
+        description: "JSON array of GOOS values for the build matrix."
+        required: false
+        type: string
+        default: '["linux","darwin","windows"]'
+
+      build-matrix-arch:
+        description: "JSON array of GOARCH values for the build matrix."
+        required: false
+        type: string
+        default: '["amd64","arm64"]'
+
+      build-cmd-path:
+        description: "Go package path to build (e.g. ./cmd/augustus). Required if enable-build is true."
+        required: false
+        type: string
+        default: ""
+
+      build-binary-name:
+        description: "Base name for the built binary. Defaults to the caller repo name."
+        required: false
+        type: string
+        default: ""
+
+      enable-harden-runner:
+        description: "Whether to install StepSecurity Harden-Runner as the first step of every job."
+        required: false
+        type: boolean
+        default: true
+
+      harden-runner-policy:
+        description: "Harden-Runner egress policy: 'audit' (observe + report) or 'block' (deny by default)."
+        required: false
+        type: string
+        default: "audit"
+
+      harden-runner-allowed-endpoints:
+        description: "Newline-separated allowed egress endpoints when harden-runner-policy=block. Ignored in audit mode."
+        required: false
+        type: string
+        default: ""
+
+      upload-coverage:
+        description: "Whether to upload coverage.out to Codecov. Requires CODECOV_TOKEN secret."
+        required: false
+        type: boolean
+        default: false
+
+    secrets:
+      CODECOV_TOKEN:
+        description: "Codecov project token. Only required when upload-coverage is true."
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    if: ${{ inputs.enable-lint }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
+        with:
+          version: ${{ inputs.golangci-lint-version }}
+          args: --timeout=${{ inputs.golangci-lint-timeout }}
+          working-directory: ${{ inputs.working-directory }}
+
+  test:
+    name: Test
+    if: ${{ inputs.enable-test }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
+
+      - name: Download dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: go mod download
+
+      - name: Run tests
+        working-directory: ${{ inputs.working-directory }}
+        run: go test ${{ inputs.test-flags }} ${{ inputs.test-packages }}
+
+      - name: Upload coverage
+        if: ${{ inputs.upload-coverage && inputs.enable-test }}
+        uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c  # v5.5.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ inputs.working-directory }}/coverage.out
+
+  build:
+    name: Build
+    if: ${{ inputs.enable-build && inputs.build-cmd-path != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: ${{ fromJSON(inputs.build-matrix-os) }}
+        goarch: ${{ fromJSON(inputs.build-matrix-arch) }}
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
+
+      - name: Determine binary name
+        id: binary
+        run: |
+          if [ -n "${{ inputs.build-binary-name }}" ]; then
+            echo "name=${{ inputs.build-binary-name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          go build -trimpath -ldflags="-s -w" \
+            -o "${{ steps.binary.outputs.name }}-${{ matrix.goos }}-${{ matrix.goarch }}" \
+            ${{ inputs.build-cmd-path }}

--- a/.github/workflows/test-go-ci.yml
+++ b/.github/workflows/test-go-ci.yml
@@ -1,0 +1,53 @@
+name: Test go-ci.yml (self-test)
+# Self-test harness for the go-ci.yml reusable workflow.
+# On every PR that touches go-ci.yml or the test fixture, this workflow invokes
+# go-ci.yml locally against _test-fixtures/go-minimal and confirms lint+test+build pass.
+# This catches regressions before consumers pull a new SHA.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/go-ci.yml'
+      - '.github/workflows/test-go-ci.yml'
+      - '_test-fixtures/go-minimal/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  call-go-ci-defaults:
+    name: Call go-ci (defaults)
+    # Local reference — uses the workflow from THIS commit (caller and callee in same repo).
+    uses: ./.github/workflows/go-ci.yml
+    permissions:
+      contents: read
+    with:
+      working-directory: _test-fixtures/go-minimal
+      build-cmd-path: ./cmd/minimal
+      build-binary-name: minimal
+      # Reduced matrix for the self-test to keep CI fast; production default is fuller.
+      build-matrix-os: '["linux"]'
+      build-matrix-arch: '["amd64"]'
+
+  call-go-ci-lint-disabled:
+    name: Call go-ci (lint disabled)
+    uses: ./.github/workflows/go-ci.yml
+    permissions:
+      contents: read
+    with:
+      working-directory: _test-fixtures/go-minimal
+      enable-lint: false
+      build-cmd-path: ./cmd/minimal
+      build-binary-name: minimal
+      build-matrix-os: '["linux"]'
+      build-matrix-arch: '["amd64"]'
+
+  call-go-ci-no-build:
+    name: Call go-ci (build disabled)
+    uses: ./.github/workflows/go-ci.yml
+    permissions:
+      contents: read
+    with:
+      working-directory: _test-fixtures/go-minimal
+      enable-build: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Built binaries from self-test / local runs
+_test-fixtures/**/minimal
+_test-fixtures/**/*-*
+coverage.out

--- a/README.md
+++ b/README.md
@@ -1,4 +1,103 @@
-# What is in this repo?
-This repo hosts the GitHub workflows that are callable from Praetorian's internal and public repositories.
+# public-workflows
 
-# **IMPORTANT:** Do not put propertiary information in the workflows
+Reusable GitHub Actions workflows callable from any repository in the `praetorian-inc` organization.
+
+> **IMPORTANT:** Do not put proprietary information in these workflows. They are intended to be consumable by public repos.
+
+## Access
+
+These workflows are invocable from any `praetorian-inc` org repository via the repo-level setting:
+
+`Settings → Actions → General → Access → Accessible from repositories in the 'praetorian-inc' organization`
+
+This setting bypasses the org-level "Selected actions" allowlist for same-org reusable workflow calls. Callers should still pin by commit SHA.
+
+## Available workflows
+
+### `go-ci.yml` — Go CI (lint + test + build)
+
+One-stop reusable workflow for Go repositories. Provides lint (golangci-lint), test (go test with race + coverage), and cross-platform build matrix, with StepSecurity Harden-Runner enabled by default.
+
+**Minimal caller** (drop this in `.github/workflows/ci.yml` of a consumer repo):
+
+```yaml
+name: CI
+on:
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@<SHA>  # v1.0.0
+    permissions:
+      contents: read
+    with:
+      build-cmd-path: ./cmd/myapp
+    secrets: inherit
+```
+
+**All inputs** (all optional with sensible defaults):
+
+| Input | Default | Purpose |
+|---|---|---|
+| `working-directory` | `.` | Working dir for multi-module repos |
+| `go-version-file` | `go.mod` | Path to go.mod (relative to `working-directory`) |
+| `enable-lint` | `true` | Run golangci-lint |
+| `golangci-lint-version` | `v2.11.4` | Pinned golangci-lint binary version (never `latest`) |
+| `golangci-lint-timeout` | `5m` | Lint timeout |
+| `enable-test` | `true` | Run `go test` |
+| `test-flags` | `-race -coverprofile=coverage.out -covermode=atomic` | Flags for `go test` |
+| `test-packages` | `./...` | Package selector for `go test` |
+| `enable-build` | `true` | Run cross-platform build matrix (requires `build-cmd-path`) |
+| `build-matrix-os` | `["linux","darwin","windows"]` | GOOS matrix (JSON) |
+| `build-matrix-arch` | `["amd64","arm64"]` | GOARCH matrix (JSON) |
+| `build-cmd-path` | `""` | Go package path to build (e.g. `./cmd/augustus`). Build job skipped if empty. |
+| `build-binary-name` | repo name | Base name for the built binary |
+| `enable-harden-runner` | `true` | Install StepSecurity Harden-Runner as first step of every job |
+| `harden-runner-policy` | `audit` | `audit` (observe) or `block` (deny-by-default egress) |
+| `harden-runner-allowed-endpoints` | `""` | Newline-separated allowlist for block mode |
+| `upload-coverage` | `false` | Upload `coverage.out` to Codecov (requires `CODECOV_TOKEN` secret) |
+
+**Secrets:**
+- `CODECOV_TOKEN` — required only if `upload-coverage: true`
+
+### `claude-code.yml` — Claude PR Assistant
+
+Runs Claude Code review on PRs. See the workflow file for input documentation.
+
+### `unit-tests.yml` — Unit tests for claude-tool-sdk consumers (npm/Node.js)
+
+Callable workflow for repos that use the private `claude-tool-sdk` module. Generates a short-lived GitHub App token to fetch the private dependency, then runs `npm ci` + `npm test`.
+
+### `version-{bump,check,set}.yml` — Claude plugin version management
+
+Three workflows that manage `.claude-plugin/plugin.json` version lifecycle on PRs.
+
+## Pinning requirements
+
+Consumers **must** pin reusable workflow references by SHA (not tag or branch) per the org's supply-chain hardening policy:
+
+```yaml
+# ✓ Allowed
+uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@abc123...def456  # v1.0.0
+
+# ✗ Forbidden (tag and branch refs drift silently)
+uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@main
+uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@v1
+```
+
+Use [ratchet](https://github.com/sethvargo/ratchet) to auto-pin.
+
+## Contributing
+
+1. Workflows in `.github/workflows/*.yml` must SHA-pin all `uses:` references. `ratchet lint` enforces this.
+2. The `test-go-ci.yml` self-test harness exercises `go-ci.yml` against the `_test-fixtures/go-minimal/` module on every PR — keep it passing.
+3. Tag new major versions (`vX.Y.Z`) after merge; consumers pin to the SHA of that tagged commit.
+
+## Supply chain context
+
+See https://linear.app/praetorianlabs/issue/ENG-3079 for the CI/CD supply chain hardening initiative that motivates this repo's design.

--- a/_test-fixtures/go-minimal/cmd/minimal/main.go
+++ b/_test-fixtures/go-minimal/cmd/minimal/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	minimal "github.com/praetorian-inc/public-workflows/_test-fixtures/go-minimal"
+)
+
+func main() {
+	fmt.Println(minimal.Greet(""))
+}

--- a/_test-fixtures/go-minimal/go.mod
+++ b/_test-fixtures/go-minimal/go.mod
@@ -1,0 +1,3 @@
+module github.com/praetorian-inc/public-workflows/_test-fixtures/go-minimal
+
+go 1.25.3

--- a/_test-fixtures/go-minimal/hello.go
+++ b/_test-fixtures/go-minimal/hello.go
@@ -1,0 +1,8 @@
+package minimal
+
+func Greet(name string) string {
+	if name == "" {
+		return "hello, world"
+	}
+	return "hello, " + name
+}

--- a/_test-fixtures/go-minimal/hello_test.go
+++ b/_test-fixtures/go-minimal/hello_test.go
@@ -1,0 +1,19 @@
+package minimal
+
+import "testing"
+
+func TestGreet_Default(t *testing.T) {
+	got := Greet("")
+	want := "hello, world"
+	if got != want {
+		t.Errorf("Greet(\"\") = %q, want %q", got, want)
+	}
+}
+
+func TestGreet_Named(t *testing.T) {
+	got := Greet("praetorian")
+	want := "hello, praetorian"
+	if got != want {
+		t.Errorf("Greet(\"praetorian\") = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds go-ci.yml — a reusable workflow (workflow_call) that consumers in the praetorian-inc org can call instead of duplicating inline lint/test/build jobs per repo. Foundation commit for the CI/CD supply chain hardening initiative ([ENG-3079](https://linear.app/praetorianlabs/issue/ENG-3079)).

**What it provides:** lint (golangci-lint, pinned binary v2.11.4), test (go test -race + coverage), build (GOOS × GOARCH matrix), StepSecurity Harden-Runner as first step of every job (audit mode default).

**All internal refs SHA-pinned:**
- actions/checkout @ de0fac2e4500dabe0009e67214ff5f5447ce83dd (v6.0.2)
- actions/setup-go @ 4b73464bb391d4059bd26b0524d20df3927bd417 (v6.3.0)
- golangci/golangci-lint-action @ 1e7e51e771db61008b38414a730f564565cf7c20 (v9.2.0)
- step-security/harden-runner @ 6c3c2f2c1c457b00c10c4848d6f5491db3b629df (v2.18.0)
- codecov/codecov-action @ 125fc84a9a348dbcf27191600683ec096ec9021c (v5.5.1)

**Self-test harness:** test-go-ci.yml invokes go-ci.yml against _test-fixtures/go-minimal on every PR. Three scenarios: defaults, lint-disabled, build-disabled.

**Scope:** ~18 Go repos (14 capability + 4 guard-platform: guard-core backend, tabularium, janus, janus-framework).

**Follow-ups after merge:**
1. Tag v1.0.0
2. Pilot: migrate augustus ci.yml
3. Sweep 17 remaining repos
4. Flip Harden-Runner audit → block after 2-week bake

Linear: https://linear.app/praetorianlabs/issue/ENG-3092
Parent: https://linear.app/praetorianlabs/issue/ENG-3079