### PR TITLE
feat(go-ci): add golangci-lint-only-new-issues input (v1.0.1)

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -50,6 +50,12 @@ on:
         type: string
         default: "5m"
 
+      golangci-lint-only-new-issues:
+        description: "Report only issues introduced on lines modified in the PR, skipping pre-existing debt. Useful for repos adopting the workflow with accumulated lint backlog; set false once backlog is cleared."
+        required: false
+        type: boolean
+        default: false
+
       enable-test:
         description: "Whether to run go test."
         required: false
@@ -162,6 +168,7 @@ jobs:
           version: ${{ inputs.golangci-lint-version }}
           args: --timeout=${{ inputs.golangci-lint-timeout }}
           working-directory: ${{ inputs.working-directory }}
+          only-new-issues: ${{ inputs.golangci-lint-only-new-issues }}
 
   test:
     name: Test

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ jobs:
 | `enable-lint` | `true` | Run golangci-lint |
 | `golangci-lint-version` | `v2.11.4` | Pinned golangci-lint binary version (never `latest`) |
 | `golangci-lint-timeout` | `5m` | Lint timeout |
+| `golangci-lint-only-new-issues` | `false` | Report only issues on lines modified in the PR (useful when migrating a repo with accumulated lint debt) |
 | `enable-test` | `true` | Run `go test` |
 | `test-flags` | `-race -coverprofile=coverage.out -covermode=atomic` | Flags for `go test` |
 | `test-packages` | `./...` | Package selector for `go test` |


### PR DESCRIPTION
## Summary

Adds an opt-in input `golangci-lint-only-new-issues` (default `false`) to `go-ci.yml` so consumers with accumulated pre-existing lint debt can migrate to the centralized workflow without the lint job failing on code they didn't touch.

## Why

[Augustus pilot (ENG-3081)](https://github.com/praetorian-inc/augustus/pull/63) revealed 68 pre-existing `errcheck` violations hidden by the previously-broken CI. Most other Go capability repos have similar accumulated debt (their CI has been `startup_failure` for months and never surfaced issues). Without this flag, every migration PR would be blocked on debt cleanup unrelated to the migration itself.

## Tradeoff

- **Default stays strict** (`false`). Repos that pass lint today see no change.
- **Opt-in `true`** flags a repo as 'migrating with debt.' Pair with a Linear ticket to reach zero issues and flip back.
- golangci-lint-action has native `only-new-issues` support; this is a pass-through, no custom logic.

## Test plan

- [ ] Self-test harness passes (same 3 scenarios, unchanged behavior with default)
- [ ] After merge: tag v1.0.1, augustus PR bumps SHA + sets `golangci-lint-only-new-issues: true`

## Next

1. Merge → tag v1.0.1
2. Update augustus PR #63 with new SHA + flag
3. Validate pilot passes all 8 jobs
4. Begin 17-repo sweep; each caller sets `golangci-lint-only-new-issues: true` during migration, gets a ticket to clean up, flips back afterward

## Linear

- Ticket: https://linear.app/praetorianlabs/issue/ENG-3092 (v1.0.0 + v1.0.1 rolled up)
- Parent: https://linear.app/praetorianlabs/issue/ENG-3079