### PR TITLE
revert: remove golangci-lint-only-new-issues input from go-ci (v1.0.2)

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -50,12 +50,6 @@ on:
         type: string
         default: "5m"
 
-      golangci-lint-only-new-issues:
-        description: "Report only issues introduced on lines modified in the PR, skipping pre-existing debt. Useful for repos adopting the workflow with accumulated lint backlog; set false once backlog is cleared."
-        required: false
-        type: boolean
-        default: false
-
       enable-test:
         description: "Whether to run go test."
         required: false
@@ -168,7 +162,6 @@ jobs:
           version: ${{ inputs.golangci-lint-version }}
           args: --timeout=${{ inputs.golangci-lint-timeout }}
           working-directory: ${{ inputs.working-directory }}
-          only-new-issues: ${{ inputs.golangci-lint-only-new-issues }}
 
   test:
     name: Test

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ jobs:
 | `enable-lint` | `true` | Run golangci-lint |
 | `golangci-lint-version` | `v2.11.4` | Pinned golangci-lint binary version (never `latest`) |
 | `golangci-lint-timeout` | `5m` | Lint timeout |
-| `golangci-lint-only-new-issues` | `false` | Report only issues on lines modified in the PR (useful when migrating a repo with accumulated lint debt) |
 | `enable-test` | `true` | Run `go test` |
 | `test-flags` | `-race -coverprofile=coverage.out -covermode=atomic` | Flags for `go test` |
 | `test-packages` | `./...` | Package selector for `go test` |


### PR DESCRIPTION
## Summary

Reverts the `golangci-lint-only-new-issues` input added in v1.0.1 (#5). Consumers with pre-existing lint debt will fix their issues in separate PRs rather than opt out of strict linting.

## Why

Keeping strict-by-default-only avoids:
- Quietly disabled lint on repos that adopted the flag and never flipped it back
- Bifurcated behavior across the capability portfolio
- An API surface that exists to paper over tech debt

Supply chain hardening posture ([ENG-3079](https://linear.app/praetorianlabs/issue/ENG-3079)) is stronger when every consumer runs the same lint gate. Pre-existing debt gets fixed, not hidden.

Augustus pilot ([PR #63](https://github.com/praetorian-inc/augustus/pull/63)) stays lint-red until a separate PR lands the 68 errcheck fixes, at which point PR #63 re-runs CI on the new base and passes naturally. No API change to consumers; no one was pinned to v1.0.1 yet.

## Test plan

- [ ] Self-test harness passes (same three scenarios, flag is gone so default strict is what runs)
- [ ] After merge: tag v1.0.2
- [ ] No consumer update needed — v1.0.0 is still valid; v1.0.2 is the recommended latest

## Linear

- https://linear.app/praetorianlabs/issue/ENG-3092