### PR TITLE
feat(go-ci): add build-cgo-enabled input (v1.0.3)

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -98,6 +98,12 @@ on:
         type: string
         default: ""
 
+      build-cgo-enabled:
+        description: "CGO_ENABLED env value for the Build job. Default '0' produces static binaries and works with cross-compilation. Set '1' for packages with C bindings (e.g., go-tree-sitter, go-sqlite3). When '1', narrow build-matrix-os/arch to platforms with a C toolchain available on the runner (typically just linux/amd64) to avoid cross-compile failures."
+        required: false
+        type: string
+        default: "0"
+
       enable-harden-runner:
         description: "Whether to install StepSecurity Harden-Runner as the first step of every job."
         required: false
@@ -247,7 +253,7 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: "0"
+          CGO_ENABLED: ${{ inputs.build-cgo-enabled }}
         run: |
           go build -trimpath -ldflags="-s -w" \
             -o "${{ steps.binary.outputs.name }}-${{ matrix.goos }}-${{ matrix.goarch }}" \

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ jobs:
 | `build-matrix-arch` | `["amd64","arm64"]` | GOARCH matrix (JSON) |
 | `build-cmd-path` | `""` | Go package path to build (e.g. `./cmd/augustus`). Build job skipped if empty. |
 | `build-binary-name` | repo name | Base name for the built binary |
+| `build-cgo-enabled` | `"0"` | `CGO_ENABLED` env for Build job. Set `"1"` for C-binding packages; narrow matrix accordingly. |
 | `enable-harden-runner` | `true` | Install StepSecurity Harden-Runner as first step of every job |
 | `harden-runner-policy` | `audit` | `audit` (observe) or `block` (deny-by-default egress) |
 | `harden-runner-allowed-endpoints` | `""` | Newline-separated allowlist for block mode |


### PR DESCRIPTION
## Summary

Adds `build-cgo-enabled` input (default `"0"`) to go-ci.yml for Go repos with C-binding dependencies that need CGO during build.

## Why

[vespasian#70](https://github.com/praetorian-inc/vespasian/pull/70) revealed the gap: go-tree-sitter's `Node` type is defined in a cgo-gated source file. With `CGO_ENABLED=0` (the previous hardcoded default for static cross-compiled binaries), all 6 build matrix jobs failed with `undefined: Node`.

## Behavior

- Default remains `"0"` — unchanged for all current consumers (static binaries, full cross-compile matrix).
- Consumers with cgo deps opt in with `build-cgo-enabled: "1"` and typically narrow the build matrix to `linux/amd64` (cross-compiling cgo from linux to darwin/windows requires additional toolchain setup not covered here).
- Test job unchanged — `CGO_ENABLED` is not set there, so the runner default (CGO=1 when gcc present) applies, which is what `-race` requires.

## Test plan

- [ ] Self-test harness passes (default path unchanged)
- [ ] After merge: tag v1.0.3, update vespasian#70 with `build-cgo-enabled: "1"` + narrowed matrix

## Linear

- https://linear.app/praetorianlabs/issue/ENG-3092 (v1.0.3 rolls up into the foundation ticket)