### PR TITLE
feat(go-ci): add modcheck job — go mod verify + tidy drift (v1.0.4)

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -137,6 +137,41 @@ permissions:
   contents: read
 
 jobs:
+  modcheck:
+    name: Module integrity
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
+
+      - name: go mod verify
+        working-directory: ${{ inputs.working-directory }}
+        run: go mod verify
+
+      - name: go mod tidy drift check
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          go mod tidy -diff
+          # `go mod tidy -diff` prints the diff that would be applied and exits
+          # non-zero if go.mod/go.sum are stale relative to the actual import graph.
+
   lint:
     name: Lint
     if: ${{ inputs.enable-lint }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ This setting bypasses the org-level "Selected actions" allowlist for same-org re
 
 ### `go-ci.yml` — Go CI (lint + test + build)
 
-One-stop reusable workflow for Go repositories. Provides lint (golangci-lint), test (go test with race + coverage), and cross-platform build matrix, with StepSecurity Harden-Runner enabled by default.
+One-stop reusable workflow for Go repositories. Provides:
+- **Module integrity** (`go mod verify` + `go mod tidy -diff` drift check)
+- **Lint** (golangci-lint)
+- **Test** (`go test -race` with coverage)
+- **Cross-platform build matrix** (GOOS × GOARCH)
+- **StepSecurity Harden-Runner** runtime CI EDR (enabled by default, audit mode)
 
 **Minimal caller** (drop this in `.github/workflows/ci.yml` of a consumer repo):
 


### PR DESCRIPTION
## Summary

Adds a new `modcheck` job to go-ci.yml that runs:
- `go mod verify` — validates module cache against `go.sum` checksums (supply-chain integrity)
- `go mod tidy -diff` — fails if `go.mod`/`go.sum` are stale vs the actual import graph (dependency hygiene)

## Why

**`go mod verify`** catches module tampering — any local cache that doesn't match the recorded checksum fails the build. Cheap ('200ms), high signal.

**`go mod tidy -diff`** catches drift that accumulates silently: an import added in code but not committed to `go.mod`, or deps listed in `go.mod` that are no longer used. These drift issues don't break builds today but create surprise friction later (dependency review PRs, Dependabot noise). Exposing them early forces repos to stay clean.

## Strict-by-default

Per the lint policy set in v1.0.2 (reverting `only-new-issues`), **no opt-out flag**. Consumer repos with pre-existing drift fix it in a cleanup PR, same pattern as lint debt across the sweep.

## Job ordering

`modcheck` runs as its own job (parallel with `lint`/`test`/`build`), so module drift doesn't block the other signals from running. Fast fail: `go mod verify` is usually sub-second; `go mod tidy -diff` depends on module download speed.

## Test plan

- [ ] Self-test harness passes (fixture has clean go.mod/go.sum)
- [ ] After merge: tag v1.0.4
- [ ] Consumers bump at their convenience; drift failures surface naturally

## Linear

- https://linear.app/praetorianlabs/issue/ENG-3092