### PR TITLE
feat: add go-security.yml reusable workflow (gosec + govulncheck)

### DIFF
--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -1,0 +1,185 @@
+name: Go Security (Callable)
+# Reusable workflow for Go repositories in the praetorian-inc org.
+# Runs gosec (SAST) and govulncheck (Go vulnerability database) against the
+# caller's module and optionally uploads SARIF to the GitHub Security tab.
+#
+# Access: invocable from any repo in the praetorian-inc org
+# (Settings -> Actions -> General -> Access -> Accessible from repositories in
+# the 'praetorian-inc' organization).
+#
+# Caller example (recommended placement: .github/workflows/security.yml):
+#
+#   name: Security
+#   on:
+#     push: { branches: [main] }
+#     pull_request: { branches: [main] }
+#     schedule:
+#       - cron: '0 6 * * 1'  # Mondays 06:00 UTC
+#     workflow_dispatch: {}
+#
+#   permissions:
+#     contents: read
+#
+#   jobs:
+#     security:
+#       uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@<SHA>  # v1.0.0
+#       permissions:
+#         contents: read
+#         security-events: write  # required when upload-sarif: true (default)
+#       secrets: inherit
+#
+# Design rationale: gosec+govulncheck live in their own reusable workflow
+# (separate from go-ci.yml) because
+#   (1) they need `security-events: write` which go-ci.yml callers don't grant,
+#   (2) they typically run on a different cadence (weekly + on-push vs per-PR),
+#   (3) a broken security tool (e.g. gosec@latest requiring a newer Go) should
+#       not block builds. This matches the pattern used by kubernetes/release,
+#       ossf/scorecard, cli/cli, and prometheus/prometheus.
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: "Working directory for the Go module (useful for multi-module repos)."
+        required: false
+        type: string
+        default: "."
+
+      go-version-file:
+        description: "Path to go.mod (relative to working-directory) used as Go version source of truth for govulncheck."
+        required: false
+        type: string
+        default: "go.mod"
+
+      enable-gosec:
+        description: "Whether to run gosec SAST scanner."
+        required: false
+        type: boolean
+        default: true
+
+      gosec-args:
+        description: "Arguments passed to gosec. Defaults to observe-only (never fails the job) with SARIF output. Override to enforce: e.g. '-severity=high -fmt sarif -out gosec-results.sarif ./...'."
+        required: false
+        type: string
+        default: "-no-fail -fmt sarif -out gosec-results.sarif ./..."
+
+      enable-govulncheck:
+        description: "Whether to run govulncheck against the module."
+        required: false
+        type: boolean
+        default: true
+
+      govulncheck-package:
+        description: "Go package selector passed to govulncheck."
+        required: false
+        type: string
+        default: "./..."
+
+      upload-sarif:
+        description: "Whether to upload SARIF findings to the GitHub Security tab. When true, the caller MUST grant 'security-events: write'."
+        required: false
+        type: boolean
+        default: true
+
+      enable-harden-runner:
+        description: "Whether to install StepSecurity Harden-Runner as the first step of every job."
+        required: false
+        type: boolean
+        default: true
+
+      harden-runner-policy:
+        description: "Harden-Runner egress policy: 'audit' (observe + report) or 'block' (deny by default)."
+        required: false
+        type: string
+        default: "audit"
+
+      harden-runner-allowed-endpoints:
+        description: "Newline-separated allowed egress endpoints when harden-runner-policy=block. Ignored in audit mode."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  gosec:
+    name: Gosec
+    if: ${{ inputs.enable-gosec }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run gosec
+        uses: securego/gosec@b72378a2da300339c40788e1eddf1ddea6498558  # v2.22.11
+        with:
+          args: ${{ inputs.gosec-args }}
+
+      - name: Upload gosec SARIF
+        if: ${{ inputs.upload-sarif && always() }}
+        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734  # v3.35.2
+        with:
+          # gosec runs in a Docker container that writes output to /github/workspace,
+          # which maps to the runner's workspace root regardless of `working-directory`.
+          sarif_file: gosec-results.sarif
+          category: gosec
+
+  govulncheck:
+    name: Govulncheck
+    if: ${{ inputs.enable-govulncheck }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run govulncheck (SARIF)
+        if: ${{ inputs.upload-sarif }}
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee  # v1.0.4
+        with:
+          work-dir: ${{ inputs.working-directory }}
+          go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
+          go-package: ${{ inputs.govulncheck-package }}
+          output-format: sarif
+          output-file: govulncheck-results.sarif
+          repo-checkout: false
+
+      - name: Run govulncheck (text)
+        if: ${{ !inputs.upload-sarif }}
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee  # v1.0.4
+        with:
+          work-dir: ${{ inputs.working-directory }}
+          go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
+          go-package: ${{ inputs.govulncheck-package }}
+          repo-checkout: false
+
+      - name: Upload govulncheck SARIF
+        if: ${{ inputs.upload-sarif && always() }}
+        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734  # v3.35.2
+        with:
+          sarif_file: govulncheck-results.sarif
+          category: govulncheck

--- a/.github/workflows/test-go-security.yml
+++ b/.github/workflows/test-go-security.yml
@@ -1,0 +1,53 @@
+name: Test go-security.yml (self-test)
+# Self-test harness for the go-security.yml reusable workflow.
+# On every PR that touches go-security.yml or the test fixture, this workflow
+# invokes go-security.yml locally against _test-fixtures/go-minimal and
+# confirms gosec + govulncheck paths run. This catches regressions before
+# consumers pull a new SHA.
+#
+# SARIF upload is disabled in self-test to keep the harness stateless — we
+# don't want self-test findings polluting public-workflows's own Security tab.
+# The SARIF upload path is still covered indirectly by consumer repos that
+# adopt the workflow with upload-sarif: true.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/go-security.yml'
+      - '.github/workflows/test-go-security.yml'
+      - '_test-fixtures/go-minimal/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  call-go-security-defaults:
+    name: Call go-security (defaults, SARIF off)
+    # Local reference — uses the workflow from THIS commit (caller and callee in same repo).
+    uses: ./.github/workflows/go-security.yml
+    permissions:
+      contents: read
+    with:
+      working-directory: _test-fixtures/go-minimal
+      upload-sarif: false
+
+  call-go-security-gosec-only:
+    name: Call go-security (gosec only)
+    uses: ./.github/workflows/go-security.yml
+    permissions:
+      contents: read
+    with:
+      working-directory: _test-fixtures/go-minimal
+      enable-govulncheck: false
+      upload-sarif: false
+
+  call-go-security-govulncheck-only:
+    name: Call go-security (govulncheck only)
+    uses: ./.github/workflows/go-security.yml
+    permissions:
+      contents: read
+    with:
+      working-directory: _test-fixtures/go-minimal
+      enable-gosec: false
+      upload-sarif: false

--- a/README.md
+++ b/README.md
@@ -71,6 +71,61 @@ jobs:
 **Secrets:**
 - `CODECOV_TOKEN` — required only if `upload-coverage: true`
 
+### `go-security.yml` — Go security scanning (gosec + govulncheck)
+
+Reusable workflow for Go repositories that runs SAST (`gosec`) and Go vulnerability database scanning (`govulncheck`), optionally publishing SARIF findings to the GitHub Security tab. **Separate from `go-ci.yml`** so that:
+- callers only grant `security-events: write` when they want SARIF upload,
+- security scans can run on a different cadence (`schedule:`) than CI,
+- a broken security tool doesn't block builds (independent blast radius).
+
+This matches the pattern used by `ossf/scorecard`, `kubernetes/release`, `cli/cli`, and `prometheus/prometheus`.
+
+**Minimal caller** (drop this in `.github/workflows/security.yml` of a consumer repo):
+
+```yaml
+name: Security
+on:
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC — weekly baseline
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@<SHA>  # v1.0.0
+    permissions:
+      contents: read
+      security-events: write  # required when upload-sarif: true (default)
+    secrets: inherit
+```
+
+**All inputs** (all optional with sensible defaults):
+
+| Input | Default | Purpose |
+|---|---|---|
+| `working-directory` | `.` | Working dir for multi-module repos |
+| `go-version-file` | `go.mod` | Path to go.mod (relative to `working-directory`), drives govulncheck's Go version |
+| `enable-gosec` | `true` | Run gosec SAST scanner |
+| `gosec-args` | `-no-fail -fmt sarif -out gosec-results.sarif ./...` | Arguments passed to gosec. Defaults to observe-only. Override with e.g. `-severity=high -fmt sarif -out gosec-results.sarif ./...` to enforce. |
+| `enable-govulncheck` | `true` | Run govulncheck against the module |
+| `govulncheck-package` | `./...` | Package selector for govulncheck |
+| `upload-sarif` | `true` | Upload SARIF findings to the GitHub Security tab. When `true`, **the caller MUST grant `security-events: write`**. Set `false` to run as CI-only checks without publishing to the Security tab. |
+| `enable-harden-runner` | `true` | Install StepSecurity Harden-Runner as first step of every job |
+| `harden-runner-policy` | `audit` | `audit` (observe) or `block` (deny-by-default egress) |
+| `harden-runner-allowed-endpoints` | `""` | Newline-separated allowlist for block mode |
+
+**Pinned tool versions** (SHA-locked in the workflow, bumped via PR):
+
+| Tool | Version | Why pinned |
+|---|---|---|
+| `securego/gosec` | v2.22.11 | Docker-based action — sidesteps host Go version requirements (later gosec builds require Go 1.25+) |
+| `golang/govulncheck-action` | v1.0.4 | Stable; uses its own `stable` Go internally |
+| `github/codeql-action/upload-sarif` | v3.35.2 | Current SARIF upload action |
+
 ### `claude-code.yml` — Claude PR Assistant
 
 Runs Claude Code review on PRs. See the workflow file for input documentation.
@@ -101,7 +156,7 @@ Use [ratchet](https://github.com/sethvargo/ratchet) to auto-pin.
 ## Contributing
 
 1. Workflows in `.github/workflows/*.yml` must SHA-pin all `uses:` references. `ratchet lint` enforces this.
-2. The `test-go-ci.yml` self-test harness exercises `go-ci.yml` against the `_test-fixtures/go-minimal/` module on every PR — keep it passing.
+2. The `test-go-ci.yml` and `test-go-security.yml` self-test harnesses exercise `go-ci.yml` and `go-security.yml` against the `_test-fixtures/go-minimal/` module on every PR — keep them passing.
 3. Tag new major versions (`vX.Y.Z`) after merge; consumers pin to the SHA of that tagged commit.
 
 ## Supply chain context


### PR DESCRIPTION
## Summary

- Adds `go-security.yml` — a reusable workflow dedicated to Go security scanning, running `gosec` (SAST) and `govulncheck` (Go vulndb) as two independently-toggleable jobs.
- Adds `test-go-security.yml` self-test harness modeled on `test-go-ci.yml`, covering three call paths against `_test-fixtures/go-minimal`.
- Documents the new workflow in `README.md`.

## Root cause this fixes

brutus [PR #57](https://github.com/praetorian-inc/brutus/pull/57) broke when its `go install gosec@latest` pulled gosec v2.25.0, which requires Go 1.25+ (brutus CI runs Go 1.24.13). This is a general risk across the ~10 Go repos that already use `go-ci.yml` and the others we're about to onboard. The new workflow pins gosec via the Docker-based `securego/gosec` action (v2.22.11, image `securego/gosec:2.22.10`) — the Docker container sidesteps host Go version requirements entirely.

## Why a separate workflow (not bundled into `go-ci.yml`)

1. **Permissions scope.** SARIF upload needs `security-events: write`. `go-ci.yml` callers only grant `contents: read`. GitHub nesting rule: permissions can only be *reduced*, not elevated, down the chain. Bundling forces all `go-ci.yml` callers to grant `security-events: write` — or we conditionally disable upload (half-measure). Separation keeps grants narrow.
2. **Blast radius.** Security tool drift (exactly what bit brutus) should not block builds. Separate workflow = `go-ci.yml / {Lint,Test,Build}` still passes when `go-security.yml` breaks.
3. **Cadence.** Security scans typically run `schedule:` (weekly) plus on-push. CI runs per-PR. Combining cadences in one reusable workflow is awkward.
4. **Industry precedent.** [ossf/scorecard](https://github.com/ossf/scorecard/tree/main/.github/workflows), [kubernetes/release](https://github.com/kubernetes/release/tree/master/.github/workflows), [cli/cli](https://github.com/cli/cli/tree/trunk/.github/workflows) (uses separate `codeql.yml` + `govulncheck.yml`), and [prometheus/prometheus](https://github.com/prometheus/prometheus/tree/main/.github/workflows) all split security from CI.

## Pinned tool versions

| Tool | Pin | Why |
|---|---|---|
| `securego/gosec` | v2.22.11 (`b72378a...`) | Docker-based action. Image `securego/gosec:2.22.10` ships with its own Go toolchain — immune to host Go version drift |
| `golang/govulncheck-action` | v1.0.4 (`b625fbe...`) | Uses internal `stable` Go to install govulncheck |
| `github/codeql-action/upload-sarif` | v3.35.2 (`b2f9ef8...`) | Current SARIF publisher |
| `step-security/harden-runner` | v2.18.0 (`6c3c2f2...`) | Same pin as `go-ci.yml` |
| `actions/checkout` | v6.0.2 (`de0fac2...`) | Same pin as `go-ci.yml` |

## Caller pattern (documented in README)

```yaml
name: Security
on:
  push: { branches: [main] }
  pull_request: { branches: [main] }
  schedule:
    - cron: '0 6 * * 1'  # Mondays 06:00 UTC
  workflow_dispatch: {}

permissions:
  contents: read

jobs:
  security:
    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@<SHA>  # v1.0.0
    permissions:
      contents: read
      security-events: write  # required when upload-sarif: true (default)
    secrets: inherit
```

## Rollout plan after merge

1. Tag this merge commit as `v1.1.0` (or whatever the next tag in the existing scheme is).
2. Open consumer PRs adding `.github/workflows/security.yml` to the 10 repos already using `go-ci.yml`: `augustus`, `aurelian`, `brutus` (on top of [#56](https://github.com/praetorian-inc/brutus/pull/56)), `caligula`, `cato`, `florian`, `julius`, `nerva`, `titus`, `vespasian`. brutus also removes the broken `security:` job from its old `ci.yml`.
3. Track remaining Go repos (`capability-sdk`, `constantine`, `hadrian`, `pius`, `trajan`, etc.) for migration to `go-ci.yml` + `go-security.yml` as a follow-up under ENG-3079.

## Test plan

- [x] `python3 -c yaml.safe_load` on both new files — valid YAML
- [x] `test-go-security.yml` triggers on the PR (confirms all three call paths exercise the reusable workflow with `_test-fixtures/go-minimal`)
- [ ] Reviewer: confirm `go-minimal` fixture has no gosec findings that would fail the default `-no-fail` observe-only scan
- [ ] Reviewer: confirm govulncheck finds no vulnerabilities against the fixture (expected: clean)
- [ ] Verify PR CI passes before merge

Part of ENG-3079 supply-chain hardening.