### PR TITLE
fix(go-security): remove invalid govulncheck -show flag; tolerate exit 3

### DIFF
--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload gosec SARIF
         if: ${{ inputs.upload-sarif && always() }}
-        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734  # v3.35.2
+        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0  # v4.35.2
         with:
           sarif_file: ${{ inputs.working-directory }}/gosec-results.sarif
           category: gosec
@@ -218,7 +218,7 @@ jobs:
 
       - name: Upload govulncheck SARIF
         if: ${{ inputs.upload-sarif && always() }}
-        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734  # v3.35.2
+        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0  # v4.35.2
         with:
           sarif_file: ${{ inputs.working-directory }}/govulncheck-results.sarif
           category: govulncheck

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -188,12 +188,33 @@ jobs:
       - name: Run govulncheck (SARIF)
         if: ${{ inputs.upload-sarif }}
         working-directory: ${{ inputs.working-directory }}
-        run: govulncheck -format sarif -show verbose ${{ inputs.govulncheck-package }} > govulncheck-results.sarif
+        # govulncheck exit codes: 0 = no vulns, 1 = internal error, 3 = vulns
+        # found in called code. Observe-only: don't fail CI on exit 3 (vulns);
+        # still fail on exit 1 (real errors). SARIF gets uploaded either way.
+        # Disable -e so we can capture exit 3 without aborting the step.
+        shell: bash
+        run: |
+          set +e
+          govulncheck -format sarif ${{ inputs.govulncheck-package }} > govulncheck-results.sarif
+          rc=$?
+          set -e
+          if [ $rc -ne 0 ] && [ $rc -ne 3 ]; then
+            echo "govulncheck internal error (exit $rc)" >&2
+            exit $rc
+          fi
 
       - name: Run govulncheck (text)
         if: ${{ !inputs.upload-sarif }}
         working-directory: ${{ inputs.working-directory }}
-        run: govulncheck ${{ inputs.govulncheck-package }}
+        shell: bash
+        run: |
+          set +e
+          govulncheck ${{ inputs.govulncheck-package }}
+          rc=$?
+          set -e
+          if [ $rc -ne 0 ] && [ $rc -ne 3 ]; then
+            exit $rc
+          fi
 
       - name: Upload govulncheck SARIF
         if: ${{ inputs.upload-sarif && always() }}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ jobs:
 |---|---|---|
 | `gosec` | v2.22.11 | Requires Go >= 1.24. Installed via `go install github.com/securego/gosec/v2/cmd/gosec@<version>` — the `securego/gosec` GitHub Action is not on the org allowlist, so we use a pinned `go install` instead. |
 | `govulncheck` | v1.1.4 | Requires Go >= 1.22. Installed via `go install golang.org/x/vuln/cmd/govulncheck@<version>`. |
-| `github/codeql-action/upload-sarif` | v3.35.2 | Used for SARIF upload to the Security tab (github-owned, always allowlisted). |
+| `github/codeql-action/upload-sarif` | v4.35.2 | Used for SARIF upload to the Security tab (github-owned, always allowlisted). v4 runs on Node 24; v3 was on deprecated Node 20. |
 | `actions/setup-go` | v6.3.0 | Uses `go-version: stable` — the tool binaries analyze source; they don't need to match the consumer's go.mod Go version. |
 
 ### `claude-code.yml` — Claude PR Assistant


### PR DESCRIPTION
## Summary

Second fix to `go-security.yml` after consumer PR feedback.

**Bug:** `govulncheck -format sarif -show verbose` failed because the `-show verbose` flag doesn't exist in govulncheck v1.1.4 (added in a later release). Govulncheck exited with error before writing any SARIF, leaving an empty file, which then failed `upload-sarif` with 'Invalid SARIF. JSON syntax error: Unexpected end of JSON input'.

Observed in nerva, brutus, caligula, titus, vespasian consumer PR runs.

## Changes

1. **Drop `-show verbose`** — SARIF is already structured output; no extra text mode needed for the Security-tab view.
2. **Tolerate govulncheck exit 3** (vulns found in called code) as observe-only. We still fail on exit 1 (internal error), but vuln findings proceed to SARIF upload rather than blocking CI. Matches gosec's observe-only default. Consumers who want to enforce can override the step via `enable-govulncheck: false` + their own step.
3. Wrap the command in `set +e` / `set -e` so exit 3 doesn't trip GitHub Actions' default `-eo pipefail` shell mode before we can capture the return code.

## After merge
- Tag v1.1.2
- Push another SHA-bump commit to all 10 consumer PRs (6 open + 4 already-merged need follow-up fix PRs)

Part of ENG-3079.