### PR TITLE
fix: guard govulncheck SARIF upload against empty/malformed output

### DIFF
--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -188,12 +188,55 @@ jobs:
       - name: Run govulncheck (SARIF)
         if: ${{ inputs.upload-sarif }}
         working-directory: ${{ inputs.working-directory }}
-        run: govulncheck -format sarif -show verbose ${{ inputs.govulncheck-package }} > govulncheck-results.sarif
+        shell: bash
+        # govulncheck exits 0 on clean, 3 on vulns-found, other on error. Under
+        # the default `bash -e` shell, exit 3 aborts the step mid-pipe and can
+        # leave govulncheck-results.sarif empty or truncated; the subsequent
+        # upload-sarif step (guarded by `always()`) then fails with
+        # "Invalid SARIF. JSON syntax error: Unexpected end of JSON input".
+        # We disable `-e`, tee stderr for debuggability, and fall back to a
+        # minimal valid SARIF on malformed output so upload always succeeds.
+        run: |
+          set +e
+          govulncheck -format sarif ${{ inputs.govulncheck-package }} > govulncheck-results.sarif 2> govulncheck-stderr.log
+          EXIT=$?
+          echo "govulncheck exit code: $EXIT"
+          if [ -s govulncheck-stderr.log ]; then
+            echo "::group::govulncheck stderr"
+            cat govulncheck-stderr.log
+            echo "::endgroup::"
+          fi
+          if [ ! -s govulncheck-results.sarif ] || ! python3 -c "import json,sys; json.load(open('govulncheck-results.sarif'))" 2>/dev/null; then
+            echo "::warning::govulncheck did not produce valid SARIF (exit=$EXIT). Writing empty SARIF so upload succeeds."
+            cat > govulncheck-results.sarif <<'SARIF_EOF'
+          {
+            "version": "2.1.0",
+            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            "runs": []
+          }
+          SARIF_EOF
+          fi
+          # Propagate genuine tool errors (exit 1,2) — but treat "vulns found"
+          # (exit 3) as success for CI purposes; findings surface via SARIF
+          # upload to the GitHub Security tab. Keeps security scanning
+          # non-blocking on build pipelines, per design rationale at top of file.
+          if [ $EXIT -ne 0 ] && [ $EXIT -ne 3 ]; then
+            echo "::error::govulncheck tooling error (exit=$EXIT)"
+            exit $EXIT
+          fi
 
       - name: Run govulncheck (text)
         if: ${{ !inputs.upload-sarif }}
         working-directory: ${{ inputs.working-directory }}
-        run: govulncheck ${{ inputs.govulncheck-package }}
+        # Same rationale as SARIF branch: exit 3 = vulns found; don't fail the step.
+        shell: bash
+        run: |
+          set +e
+          govulncheck ${{ inputs.govulncheck-package }}
+          EXIT=$?
+          if [ $EXIT -ne 0 ] && [ $EXIT -ne 3 ]; then
+            exit $EXIT
+          fi
 
       - name: Upload govulncheck SARIF
         if: ${{ inputs.upload-sarif && always() }}


### PR DESCRIPTION
## Problem

Observed across brutus, nerva, titus, vespasian (and likely others) after migrating to \`go-security.yml@v1.1.0\`:

\`\`\`
Post-processing sarif files: ['./govulncheck-results.sarif']
Error: Invalid SARIF. JSON syntax error: Unexpected end of JSON input
\`\`\`

## Root cause

Under the default \`bash -e\` shell, \`govulncheck\` exit code 3 (vulns found) aborts the step mid-pipe and can leave \`govulncheck-results.sarif\` empty or truncated. The subsequent \`upload-sarif\` step is guarded by \`always()\` so it still runs, loads the empty file, and fails JSON parsing.

Brutus specifically reproduces this every run (confirmed from [run 24617475813](https://github.com/praetorian-inc/brutus/actions/runs/24617475813) — govulncheck step completed in 24ms, upload-sarif saw empty file).

## Fix

1. Wrap govulncheck in \`set +e\` — don't abort on exit 3
2. Validate the SARIF is non-empty parseable JSON; if not, write a minimal valid empty SARIF so \`upload-sarif\` always has a loadable file
3. Log govulncheck's stderr if present (debuggability)
4. Treat exit 3 (vulns-found) as success at the CI level — findings still surface via GitHub Security tab, matching this workflow's design rationale (security scanning should not block builds)
5. Drop \`-show verbose\` — fluff inside SARIF, not actionable
6. Same exit-3 pass-through for the text branch (consistency)

## Validation

- \`actionlint\` clean
- After merge + tag (v1.1.1 or v1.2.0), re-run brutus's Security workflow to confirm

## Related

- Part of [ENG-3079](https://linear.app/praetorianlabs/issue/ENG-3079) CI/CD supply-chain hardening
- Sibling ticket forthcoming to track this specific regression and the 4+ affected capability repos