### PR TITLE
fix(go-security): bump codeql-action/upload-sarif v3 → v4 (Node 24)

### DIFF
--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload gosec SARIF
         if: ${{ inputs.upload-sarif && always() }}
-        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734  # v3.35.2
+        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0  # v4.35.2
         with:
           sarif_file: ${{ inputs.working-directory }}/gosec-results.sarif
           category: gosec
@@ -240,7 +240,7 @@ jobs:
 
       - name: Upload govulncheck SARIF
         if: ${{ inputs.upload-sarif && always() }}
-        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734  # v3.35.2
+        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0  # v4.35.2
         with:
           sarif_file: ${{ inputs.working-directory }}/govulncheck-results.sarif
           category: govulncheck

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ jobs:
 |---|---|---|
 | `gosec` | v2.22.11 | Requires Go >= 1.24. Installed via `go install github.com/securego/gosec/v2/cmd/gosec@<version>` — the `securego/gosec` GitHub Action is not on the org allowlist, so we use a pinned `go install` instead. |
 | `govulncheck` | v1.1.4 | Requires Go >= 1.22. Installed via `go install golang.org/x/vuln/cmd/govulncheck@<version>`. |
-| `github/codeql-action/upload-sarif` | v3.35.2 | Used for SARIF upload to the Security tab (github-owned, always allowlisted). |
+| `github/codeql-action/upload-sarif` | v4.35.2 | Used for SARIF upload to the Security tab (github-owned, always allowlisted). v4 runs on Node 24; v3 was on deprecated Node 20. |
 | `actions/setup-go` | v6.3.0 | Uses `go-version: stable` — the tool binaries analyze source; they don't need to match the consumer's go.mod Go version. |
 
 ### `claude-code.yml` — Claude PR Assistant


### PR DESCRIPTION
## Summary

Supersedes the closed #13 (PR #14 delivered its govulncheck fix).

This PR contains only the remaining change: bump `github/codeql-action/upload-sarif` from v3.35.2 to v4.35.2.

## Why

v3 runs on Node.js 20, which GitHub [deprecated in September 2025](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and will force-migrate to Node 24 on **June 2, 2026**. All 10 consumer PR runs surfaced this warning:

> `Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: github/codeql-action/upload-sarif@b2f9ef84...`

v4 is a drop-in Node 24 replacement — same action inputs, same behavior.

## After merge

- Tag v1.1.2
- Push v1.1.2 bump commit to the 6 still-open consumer PRs (aurelian, brutus, caligula, nerva, titus, vespasian)
- Open 4 follow-up fix PRs for augustus, cato, florian, julius (merged already at v1.1.0)

Part of ENG-3079.