### PR TITLE
fix(security): SHA-pin all actions + harden claude-code defaults (ENG-3093)

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -65,18 +65,19 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude PR Action
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009  # v1.0.101
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
 
       - name: Generate token for private dependencies
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
         with:
           app-id: ${{ secrets.PLUGIN_CI_APP_ID }}
           private-key: ${{ secrets.PLUGIN_CI_PRIVATE_KEY }}
@@ -34,7 +34,7 @@ jobs:
           git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "ssh://git@github.com/"
           git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "git@github.com:"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '22'
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -24,12 +24,12 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
         with:
           app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
           private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -7,9 +7,10 @@ jobs:
   version-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check version was bumped
         run: |

--- a/.github/workflows/version-set.yml
+++ b/.github/workflows/version-set.yml
@@ -37,13 +37,13 @@ jobs:
 
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
         with:
           app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
           private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Audit revealed 7 tag/branch-pinned action refs across our reusable workflows — the CVE-2025-30066 vector we're trying to protect consumers from. This pins all of them to current-release commit SHAs. Additionally downgrades \`claude-code.yml\` reusable default from \`contents: write\` to \`contents: read\` (matches stated intent — review-only).

## Pin inventory

| Action | Was | Now |
|---|---|---|
| \`anthropics/claude-code-action\` | \`@beta\` (branch!) | \`@38ec876110f9fbf8b950c79f534430740c3ac009  # v1.0.101\` |
| \`actions/checkout\` (claude-code) | \`@v5\` | \`@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1\` |
| \`actions/checkout\` (others) | \`@v4\` | \`@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1\` |
| \`actions/create-github-app-token\` | \`@v1\` | \`@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0\` |
| \`actions/setup-node\` | \`@v4\` | \`@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0\` |

## Why this matters

\`anthropics/claude-code-action@beta\` was the worst offender — a *branch* pin on a 3rd-party action that runs with \`ANTHROPIC_API_KEY\` loaded. Anthropic can push to that branch anytime.

\`actions/create-github-app-token@v1\` mints tokens from \`PLUGIN_CI_PRIVATE_KEY\` and \`VERSION_BUMPER_PRIVATE_KEY\`. If that tag is moved to malicious code (CVE-2025-30066 playbook), the attacker gets org-wide App tokens.

## Other hardening in this PR

- \`claude-code.yml\` reusable default: \`contents: write\` → \`contents: read\`. Callers can't grant more than reusable declares (intersection rule), so this also caps accidental over-granting downstream.
- Added \`persist-credentials: false\` to checkout steps that lacked it.

## Out of scope

Pre-existing shellcheck style warnings in \`claude-code.yml\` and \`github.head_ref\` untrusted-input warnings in \`version-bump.yml\` — separate follow-up.

## Closes

[ENG-3093](https://linear.app/praetorianlabs/issue/ENG-3093)