### PR TITLE
fix(security): harden claude-code.yml — allowedTools + member-only gate

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -55,12 +55,21 @@ on:
 jobs:
   claude-code-action:
     # Guard on what interaction we will run Claude, because we don't know whether the caller workflow
-    # filters correctly on the trigger.
+    # filters correctly on the trigger. We also block everyone except repo/org insiders
+    # (author_association of OWNER, MEMBER, or COLLABORATOR) to prevent prompt-injection via
+    # untrusted PRs and comments from the outside.
     if: |
       github.event.pull_request.draft == false &&
-      ((github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize'))) &&
-      !contains(github.actor, 'coderabbit') && !contains(github.actor, 'devin') && !contains(github.actor, '[bot]')
+      !contains(github.actor, 'coderabbit') && !contains(github.actor, 'devin') && !contains(github.actor, '[bot]') &&
+      (
+        (github.event_name == 'pull_request'
+          && (github.event.action == 'opened' || github.event.action == 'synchronize')
+          && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+        ||
+        (github.event_name == 'pull_request_review_comment'
+          && contains(github.event.comment.body, '@claude')
+          && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      )
 
     runs-on: ubuntu-latest
 
@@ -81,7 +90,14 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          direct_prompt: ${{ inputs.prompt }}
+          # v1 idiom: use `prompt` (not deprecated `direct_prompt`) so the hardened-prompt
+          # treatment of repo-supplied content (CLAUDE.md, PR body, comments) is applied.
+          prompt: ${{ inputs.prompt }}
+          # Restrict Claude to read-only file access + the minimum gh commands needed to
+          # review a PR and post comments. Blocks Edit/Write/arbitrary Bash/WebFetch/etc.
+          claude_args: |
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+            --max-turns 10
 
       - name: Check Test Requirements
         if: ${{ inputs.require_tests }}


### PR DESCRIPTION
## Summary

Hardens the callable Claude PR reviewer against prompt-injection from untrusted PR content. Reported by Ranganatha Rao Sridhar on 2026-04-19 (internal Slack) — same class of issue we flagged to Anthropic recently.

- **External-PR lockdown**: `pull_request` and `pull_request_review_comment` triggers now gate on `author_association ∈ {OWNER, MEMBER, COLLABORATOR}`. Fork PRs and outside commenters can no longer spin up a Claude run.
- **Tool restriction**: `claude_args: --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"` — Claude is now limited to read-only file access + the minimum `gh` commands needed to review and comment. Edit/Write/arbitrary Bash/WebFetch/sub-agents are all blocked.
- **v1 idiom**: `direct_prompt` → `prompt`. `direct_prompt` is the deprecated beta input; `prompt` is where v1's hardened-prompt treatment of repo-supplied content (CLAUDE.md, PR body, comments) applies.
- Also caps `--max-turns 10`.
- Action pin unchanged — already on `@v1.0.101` (SHA-pinned).

## Blast radius

All 9 known callers reference `@main` (unpinned — separate ENG-3079 follow-up), so this ships immediately to every claude-code.yml caller on merge. None of them override the prompt restrictively, so the tool allowlist kicks in org-wide.

## Test plan

- [ ] Open a PR from an org member — Claude posts a review comment as usual
- [ ] Open a PR from an account with `author_association: NONE` (e.g., a fork) — job is skipped, no Claude run
- [ ] @claude mention in a PR review comment from an org member — Claude responds
- [ ] @claude mention from an external user — job is skipped
- [ ] Confirm Claude cannot Edit/Write files or run arbitrary Bash (check action logs for tool-denied messages if it tries)

## References

- [claude-code-action v1 migration guide](https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md)
- [claude-code-action security.md](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md)
- [GitHub fork-approval docs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/approve-runs-from-forks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)