### PR TITLE
fix(security): add MCP inline-comment + disallowedTools + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS for praetorian-inc/public-workflows
+#
+# Reusable workflows in this repo are called by 49+ repos across the org. A malicious
+# or careless change propagates immediately to every caller on `@main` and to any caller
+# pinned to a freshly-tagged SHA that includes the change. Security-sensitive files
+# require review from the security team regardless of author.
+#
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner — repo maintainer
+*                                           @nsportsman
+
+# Claude-code.yml reviews content from PRs (including CLAUDE.md, PR bodies, comments)
+# through Claude with a hardcoded, non-configurable tool allowlist. Any change to the
+# allowlist, trigger gates, or Claude invocation requires Security Engineering review
+# so we don't regress the prompt-injection defenses documented in the file's comments.
+#
+# Context: anthropics/claude-code-action#860 (track_progress silently widens allowlist),
+# Aikido PromptPwnd disclosure, tj-actions CVE-2025-30066.
+/.github/workflows/claude-code.yml          @praetorian-inc/security-engineering @nsportsman

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -93,10 +93,30 @@ jobs:
           # v1 idiom: use `prompt` (not deprecated `direct_prompt`) so the hardened-prompt
           # treatment of repo-supplied content (CLAUDE.md, PR body, comments) is applied.
           prompt: ${{ inputs.prompt }}
-          # Restrict Claude to read-only file access + the minimum gh commands needed to
-          # review a PR and post comments. Blocks Edit/Write/arbitrary Bash/WebFetch/etc.
+          # Hardened, non-configurable toolset. Callers cannot widen this — see
+          # praetorian-inc/public-workflows CODEOWNERS: any change requires AppSec review.
+          #
+          # Allow:
+          #   - Bash(gh pr {comment,diff,view}:*) — the minimum gh surface for PR review
+          #   - Read / Grep / Glob — read-only file access (prompts often reference
+          #     .claude/skills/*.md or repo docs)
+          #   - mcp__github_inline_comment__create_inline_comment — Anthropic's purpose-built
+          #     MCP for line-anchored review comments. Scoped to the current PR; cannot run
+          #     arbitrary API calls. Gives all callers CodeRabbit-style inline review.
+          #
+          # Deny (belt-and-suspenders vs anthropics/claude-code-action#860 class regressions
+          # where an upstream flag silently re-expands the allowlist via union-merge):
+          #   - Bash(curl:*) / Bash(wget:*) — exfiltration vectors
+          #   - Bash(gh api:*) / Bash(gh auth:*) — broad GitHub API / token access
+          #   - Write / Edit / MultiEdit — file mutation
+          #
+          # NEVER add `track_progress: true` here or in any caller's claude_args. It forces
+          # "tag mode" which union-merges write tools (Edit, MultiEdit, Write, git push, ...)
+          # into the allowlist and makes --allowedTools cosmetic. See
+          # anthropics/claude-code-action#860.
           claude_args: |
-            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment"
+            --disallowedTools "Bash(curl:*),Bash(wget:*),Bash(gh api:*),Bash(gh auth:*),Write,Edit,MultiEdit"
             --max-turns 10
 
       - name: Check Test Requirements


### PR DESCRIPTION
## Summary

Follow-up to #18. Closes remaining gaps identified by security-lead review (ENG-3114).

1. **+1 tool: `mcp__github_inline_comment__create_inline_comment`** — Anthropic's purpose-built MCP for line-anchored PR comments. Scoped to current PR, cannot make arbitrary API calls, has a built-in classification system that buffers + filters test/probe comments. Gives every caller CodeRabbit-style inline review.
2. **`--disallowedTools` post-filter** — belt-and-suspenders against [anthropics/claude-code-action#860](https://github.com/anthropics/claude-code-action/issues/860)-class regressions where an upstream flag silently re-expands the allowlist via union-merge. Explicitly denies `Bash(curl:*)`, `Bash(wget:*)`, `Bash(gh api:*)`, `Bash(gh auth:*)`, `Write`, `Edit`, `MultiEdit`.
3. **CODEOWNERS** on `/.github/workflows/claude-code.yml` — any future change requires `praetorian-inc/security-engineering` review. Coalition pattern for central security workflows at scale.
4. **Strong in-file comments** explaining allow/deny rationale + the `track_progress: true` trap.

## Why no caller-configurable `allowed_tools` input

Considered four patterns (hardcode, configurable, additive-only, named profiles). Security-lead verdict: only hardcoded is defensible.

- **Configurable** → callers widen "just in case" = de-facto unrestricted allowlist in 6 months (Coalition's 600-repo lesson).
- **Additive-only** → `Bash(curl:*)` is a one-line exfil path.
- **Named profiles** → delays the governance problem; `with-write` is exactly the profile PromptPwnd warns about.

## Functional wins for callers

Before #18 + this PR:
- 45 callers reviewed PRs with **no tool restriction** (Claude had Edit/Write/arbitrary Bash)
- 4 direct callers (orator, aurelian, MSP-Triage-Insights-Helper, etc.) each ran their own inline-hardened workflow with different tool lists

After #18 + this PR:
- 1 reusable workflow, 1 hardened allowlist, 1 deny post-filter, 1 set of gates
- Every caller — 45 existing + future — gets inline-review **for free** once they bump to the new tag
- Zero caller configurability = zero policy drift

## Release plan

- Merge → tag `v2.0.3` (incremental from `v2.0.2`; bundles #18 + this PR)
- Caller SHA bumps tracked in ENG-3113 (12 stale-SHA + 33 @main)
- Direct-caller migrations tracked in ENG-3114 (orator #125 closed + re-done, aurelian, MSP-Triage-Insights-Helper)

## Sources

- [Aikido PromptPwnd disclosure](https://www.aikido.dev/blog/promptpwnd-github-actions-ai-agents) — the attack we defend against
- [Coalition — centralizing security automation](https://www.coalitioninc.com/blog/centralizing-security-automation-github-reusable-actions) — CODEOWNERS pattern
- [claude-code-action solutions.md](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md) — Anthropic's recommended allowlist including this MCP tool
- [anthropics/claude-code-action#860](https://github.com/anthropics/claude-code-action/issues/860) — track_progress union-merge bug = reason for --disallowedTools floor
- tj-actions CVE-2025-30066 + trivy-action March 2026 force-push — reason for SHA-pinning (landed in #18)

## Test plan

- [ ] Merge on a test PR (e.g. this one) → inline comments render as line-anchored
- [ ] Confirm caller cannot override allowedTools by passing extra args (there's no such input)
- [ ] Confirm `Bash(curl foo)` in a prompt → denied by post-filter
- [ ] CODEOWNERS blocks merge without security-engineering review for future changes to claude-code.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)