### PR TITLE
fix(security): v2.0.5 — explicit author_association equality fixes skip bug

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -70,12 +70,18 @@ jobs:
       (
         (github.event_name == 'pull_request'
           && (github.event.action == 'opened' || github.event.action == 'synchronize')
-          && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+          && (github.event.pull_request.author_association == 'OWNER'
+              || github.event.pull_request.author_association == 'MEMBER'
+              || github.event.pull_request.author_association == 'COLLABORATOR'))
         ||
         (github.event_name == 'pull_request_review_comment'
           && contains(github.event.comment.body, '@claude')
-          && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-          && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+          && (github.event.comment.author_association == 'OWNER'
+              || github.event.comment.author_association == 'MEMBER'
+              || github.event.comment.author_association == 'COLLABORATOR')
+          && (github.event.pull_request.author_association == 'OWNER'
+              || github.event.pull_request.author_association == 'MEMBER'
+              || github.event.pull_request.author_association == 'COLLABORATOR'))
       )
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

v2.0.3/v2.0.4 runs skip even for valid insider PRs. Root cause: the `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), X)` pattern in the job-level `if:` evaluates to false in reusable-workflow context. Runs log `conclusion: skipped, steps: []` with no diagnostic.

**Proof**: orator PRs under v2.0.2 succeed (pre-hardening `if:`); all PRs opened today under v2.0.3/v2.0.4 skip even with `author_association == MEMBER` confirmed via API.

## Fix

Rewrite `contains(fromJSON(...), X)` as explicit string equality:

```diff
- && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+ && (github.event.pull_request.author_association == 'OWNER'
+     || github.event.pull_request.author_association == 'MEMBER'
+     || github.event.pull_request.author_association == 'COLLABORATOR'))
```

Semantically identical. Avoids `fromJSON` entirely.

## Security posture unchanged

All hardening from v2.0.3/v2.0.4 preserved:
- Both author_association checks on review_comment branch (PR author + commenter must be insiders — P0 comment-and-control defense)
- `--allowedTools` + `--disallowedTools` floor
- `track_progress: "false"`
- `--append-system-prompt` defensive preamble

Only the implementation of the insider check changed.

## Rollout

1. Merge this PR
2. Tag `v2.0.5` at the merge SHA
3. Bulk-bump all 46 pending caller PRs from v2.0.4 → v2.0.5 SHA (one commit appended to each existing PR)
4. Verify one canary caller (titus) runs Claude with `conclusion: success`, not `skipped`

## References

- Earlier PRs in this sweep: #18, #19, #20
- ENG-3113, ENG-3114, parent ENG-3079

🤖 Generated with [Claude Code](https://claude.com/claude-code)