### PR TITLE
fix(ci): parameterize Harden-Runner in external-contrib-notify (consistency pass)

### DIFF
--- a/.github/workflows/external-contrib-notify.yml
+++ b/.github/workflows/external-contrib-notify.yml
@@ -62,6 +62,24 @@ on:
         type: boolean
         default: true
 
+      enable-harden-runner:
+        description: "Whether to install StepSecurity Harden-Runner as the first step of the job."
+        required: false
+        type: boolean
+        default: true
+
+      harden-runner-policy:
+        description: "Harden-Runner egress policy: 'audit' (observe + report) or 'block' (deny by default)."
+        required: false
+        type: string
+        default: "audit"
+
+      harden-runner-allowed-endpoints:
+        description: "Newline-separated allowed egress endpoints when harden-runner-policy=block. Ignored in audit mode. Recommended for block mode: api.github.com:443, api.linear.app:443, slack.com:443, hooks.slack.com:443."
+        required: false
+        type: string
+        default: ""
+
     secrets:
       EXTERNAL_CONTRIB_APP_ID:
         description: "GitHub App ID (or Client ID) for praetorian-external-contrib-bot."
@@ -102,9 +120,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden runner
+        if: ${{ inputs.enable-harden-runner }}
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
 
       - name: Run external-contrib-action
         uses: praetorian-inc/external-contrib-action@08e2bdbda0ab914fa00503b31a791a93213dc789  # v3.0.0


### PR DESCRIPTION
## Summary

Closes the last cross-workflow asymmetry: `go-ci.yml`, `go-security.yml`, and (as of v2.0.9) `claude-code.yml` all parameterize Harden-Runner via three standard inputs. `external-contrib-notify.yml` hardcoded `egress-policy: audit` with no knobs. This PR brings it in line.

## Diff

- **Added**: `enable-harden-runner`, `harden-runner-policy`, `harden-runner-allowed-endpoints` inputs (identical shape to the other three workflows)
- **Changed**: the `Harden runner` step gains an `if:` guard and its `egress-policy` / `allowed-endpoints` now read from inputs

Defaults preserve current behavior (audit mode, always on). Backwards-compatible — no caller breakage.

## Why it matters for this workflow

`external-contrib-notify.yml` handles three high-value secrets:
- `LINEAR_API_KEY` — Linear org issue read/write
- `SLACK_BOT_TOKEN` — Slack channel write
- `EXTERNAL_CONTRIB_APP_PRIVATE_KEY` — **GitHub App private key** (can mint tokens with `issues:write` + `pull_requests:write` on consumer repos)

If this workflow ever runs compromised code (tj-actions / trivy-action class attack), block-mode Harden-Runner with a strict allowed-endpoints list prevents exfiltration. Documented inline:

```
api.github.com:443
api.linear.app:443
slack.com:443
hooks.slack.com:443
```

## Release plan

Merge → tag (next external-contrib version) → consumers optionally rebump to pick up the new knobs. Not urgent since audit-mode default matches today's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)