### PR TITLE
chore(hardening): v2.0.11 — timeout-minutes, block-mode endpoint docs, ACTIONS_STEP_DEBUG warning

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -93,6 +93,10 @@ jobs:
           && contains(github.event.comment.body, '@claude'))
       )
     runs-on: ubuntu-latest
+    # Wall-clock ceiling. Preflight is a small gh-api + grep step; 5 min is
+    # >20x the p99. Cap blocks a runaway shell loop or a stuck gh-api retry
+    # from sitting on the runner for the 6-hour GitHub default.
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write  # needed to post the "skipped — non-code PR" status comment
@@ -187,6 +191,15 @@ jobs:
       )
 
     runs-on: ubuntu-latest
+
+    # Wall-clock ceiling on the Claude review job. `--max-turns 15` caps
+    # the number of tool-call turns, but NOT wall time (a long-running
+    # tool call or a slow Opus response can still burn runner minutes).
+    # An injection-induced loop or a wedged network call would otherwise
+    # sit on a runner for GitHub's 6-hour default. 15 min is ~5x the p99
+    # for our review prompt and is tight enough to make a stuck job
+    # noticeable without false-positive-failing legitimate large-PR reviews.
+    timeout-minutes: 15
 
     permissions:
       contents: read

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -117,7 +117,7 @@ on:
         default: "audit"
 
       harden-runner-allowed-endpoints:
-        description: "Newline-separated allowed egress endpoints when harden-runner-policy=block. Ignored in audit mode."
+        description: "Newline-separated allowed egress endpoints when harden-runner-policy=block. Ignored in audit mode. Recommended for block mode: proxy.golang.org:443, sum.golang.org:443, github.com:443, api.github.com:443, release-assets.githubusercontent.com:443, objects.githubusercontent.com:443, storage.googleapis.com:443. If upload-coverage: true, also add: cli.codecov.io:443, api.codecov.io:443, storage.googleapis.com:443."
         required: false
         type: string
         default: ""
@@ -140,6 +140,7 @@ jobs:
   modcheck:
     name: Module integrity
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -176,6 +177,7 @@ jobs:
     name: Lint
     if: ${{ inputs.enable-lint }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -208,6 +210,7 @@ jobs:
     name: Test
     if: ${{ inputs.enable-test }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -248,6 +251,7 @@ jobs:
     name: Build
     if: ${{ inputs.enable-build && inputs.build-cmd-path != '' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -107,7 +107,7 @@ on:
         default: "audit"
 
       harden-runner-allowed-endpoints:
-        description: "Newline-separated allowed egress endpoints when harden-runner-policy=block. Ignored in audit mode."
+        description: "Newline-separated allowed egress endpoints when harden-runner-policy=block. Ignored in audit mode. Recommended for block mode: proxy.golang.org:443, sum.golang.org:443, vuln.go.dev:443, github.com:443, api.github.com:443, release-assets.githubusercontent.com:443, objects.githubusercontent.com:443, storage.googleapis.com:443."
         required: false
         type: string
         default: ""
@@ -120,6 +120,7 @@ jobs:
     name: Gosec
     if: ${{ inputs.enable-gosec }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write
@@ -160,6 +161,7 @@ jobs:
     name: Govulncheck
     if: ${{ inputs.enable-govulncheck }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   version-bump:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Only run on PR open or when 'bump' label is added
     if: >-
       github.event.action == 'opened' ||

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   version-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:

--- a/.github/workflows/version-set.yml
+++ b/.github/workflows/version-set.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   set-version:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ jobs:
 
 Runs Claude as a PR reviewer. **All security posture is hardcoded in the reusable workflow.** Callers cannot widen the tool allowlist, relax the gates, change the model, or override the hardening — any such change requires a PR to this repo with `@praetorian-inc/security-engineering` review (see CODEOWNERS).
 
-**Security posture** (as of v2.0.9, SHA `c4e898f83b9c4008cc3dbe295cc420e53ec6b16b`):
+**Security posture** (as of v2.0.11):
 
 - **Same-repo-only gate**: `github.event.pull_request.head.repo.full_name == github.repository`. Fork PRs are blocked outright — stricter than the previously-used `author_association` check (which reports org members as `CONTRIBUTOR` on public repos and silently skipped runs, hit in v2.0.3-v2.0.5). Closes the CVSS 9.4 [comment-and-control](https://oddguan.com/blog/comment-and-control-prompt-injection-credential-theft-claude-code-gemini-cli-github-copilot/) attack path on both PR and review-comment triggers.
 - **Preflight job** skips Claude entirely on docs-only PRs (files matching `*.md / *.markdown / *.rst / *.txt / docs/** / LICENSE / .gitignore / CODEOWNERS / images`). Uses paginated `gh api pulls/N/files` (handles PRs >100 files per cli/cli#5368). `@claude` on a PR review comment bypasses the filter (documented override).
@@ -145,7 +145,10 @@ Runs Claude as a PR reviewer. **All security posture is hardcoded in the reusabl
 - **StepSecurity Harden-Runner** installed as the first step of both jobs (preflight + claude-code-action). Parameterized via `enable-harden-runner` / `harden-runner-policy` / `harden-runner-allowed-endpoints` inputs — audit mode by default. Matches the pattern in `go-ci.yml` / `go-security.yml`.
 - `actions/checkout` pinned by SHA, `persist-credentials: false`, `fetch-depth: 1`.
 - `anthropics/claude-code-action` pinned by SHA (`@38ec876...` = v1.0.101).
+- **Wall-clock ceiling**: `timeout-minutes: 5` on preflight, `15` on the claude-code-action job. `--max-turns 15` caps tool-call turns but not wall time; these ceilings bound a wedged network call, a stuck Opus response, or a prompt-injection-induced loop before it can sit on a runner for GitHub's 6-hour default.
 - **CODEOWNERS** (`.github/CODEOWNERS`) enforces `@praetorian-inc/security-engineering` review on this file.
+
+> ⚠️ **Do NOT enable `ACTIONS_STEP_DEBUG=true` on repos that call this reusable.** The upstream `claude-code-action` auto-enables `show_full_output` under debug logging, which can expose PR content, tool outputs, and the contents of the internal `execution_file` into Actions logs. On public repos those logs are world-readable; on private repos they're readable by anyone with repo read access. If you need to debug a Claude run, do it locally against a test repo, not by flipping debug on a production caller.
 
 **Default review prompt** produces a 3-section summary: `### Critical issues` / `### Security` / `### Test coverage`. Explicitly defers style nits to CodeRabbit + Codex. Callers can override via the `prompt` input.
 
@@ -166,7 +169,7 @@ permissions:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@<SHA>  # v2.0.9
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@<SHA>  # v2.0.11
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Three defense-in-depth improvements from a source-level audit against 15 external hardening writeups ([oddguan "Comment and Control"](https://oddguan.com/blog/comment-and-control-prompt-injection-credential-theft-claude-code-gemini-cli-github-copilot/), [Stawinski "Trusting Claude With a Knife"](https://johnstawinski.com/2026/02/28/trusting-claude-with-a-knife-rce-claude-code-action/), [anthropics/claude-code-action#860](https://github.com/anthropics/claude-code-action/issues/860), StepSecurity Harden-Runner guidance).

## 1. `timeout-minutes` on 9 previously-uncapped jobs

| Workflow | Job | New timeout |
|---|---|---|
| `claude-code.yml` | preflight | 5 |
| `claude-code.yml` | claude-code-action | 15 |
| `go-ci.yml` | modcheck | 10 |
| `go-ci.yml` | lint | 10 |
| `go-ci.yml` | test | 15 |
| `go-ci.yml` | build | 15 |
| `go-security.yml` | gosec | 10 |
| `go-security.yml` | govulncheck | 10 |
| `version-bump.yml` | version-bump | 5 |
| `version-check.yml` | version-check | 5 |
| `version-set.yml` | set-version | 5 |

Default is GitHub's 6-hour cap. `--max-turns 15` in `claude-code.yml` bounds tool-call turns but **not wall time** — a wedged network call, a stuck Opus response, or a prompt-injection-induced loop can still burn hours. Wall-clock ceilings make this a non-event.

## 2. Block-mode endpoint docs for `go-ci.yml` + `go-security.yml`

Input description previously said only: "Newline-separated allowed egress endpoints when harden-runner-policy=block. Ignored in audit mode." — with no concrete list. Callers switching to `block` would have to trial-and-error.

New descriptions include the minimum set:
- **go-ci.yml:** `proxy.golang.org:443, sum.golang.org:443, github.com:443, api.github.com:443, release-assets.githubusercontent.com:443, objects.githubusercontent.com:443, storage.googleapis.com:443` (+ codecov hosts if `upload-coverage: true`)
- **go-security.yml:** same base + `vuln.go.dev:443` (govulncheck)

### NOT adding `pypi.org:443` or `bun.sh:443` to `claude-code.yml`

Source-verified at `claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009` (v1.0.101):
- `action.yml`, `base-action/action.yml`, `package.json` have zero `pip`/`pypi`/`python` references — no Python deps.
- `oven-sh/setup-bun@v2.1.2` compiled `dist/setup/index.js` has zero `bun.sh` references — it pulls Bun from `github.com/oven-sh/bun/releases/download/…`, already covered by our existing `release-assets.githubusercontent.com:443`.

The `pypi.org` / `bun.sh` pairing shows up in StepSecurity's generic "Claude Code" recipe — that recipe covers the *local CLI* (which has Python MCP plumbing), not the GitHub Action. Confusion avoided.

## 3. `ACTIONS_STEP_DEBUG` warning in README

Upstream `claude-code-action` auto-enables `show_full_output` when `ACTIONS_STEP_DEBUG=true`. That exposes PR content, tool outputs, and the contents of the internal `execution_file` (referenced at `claude-code.yml:261-266` for the test-requirement check) into Actions logs. On public repos: world-readable. On private repos: readable by any collaborator. README now carries an explicit banner warning users not to flip debug on production callers.

## Not breaking

Existing callers on v2.0.10 (`135c500`) continue to work. Wall-clock ceilings are non-breaking for any run that completes in reasonable time. Post-merge: tag `v2.0.11`, then a follow-up caller sweep bumps all 18 capability repos + ~16 plugin repos (currently on `@main` or `135c500`) to the new SHA.

## Items deliberately out of scope

- **Read-tool deny list via action's `settings:` input** (oddguan residual: `Read(/proc/*/environ)` bypasses the `--disallowedTools` Bash blocklist). Needs a live test that `claude-code-action` v1 honors `permissions.deny` the same way the CLI does. Will land in v2.1.0 if validated.
- **Issue #860 `track_progress` union-merge**: still OPEN, code path verified live in v1.0.101 source (`src/modes/detector.ts` forces tag mode; `base-action/src/parse-sdk-options.ts` constructs `mergedAllowedTools` from union). Our `track_progress: "false"` defense remains correct and necessary.