### PR TITLE
fix(go-security): add 'actions: read' for codeql-action/upload-sarif

### DIFF
--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -22,10 +22,11 @@ name: Go Security (Callable)
 #
 #   jobs:
 #     security:
-#       uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@<SHA>  # v1.1.0
+#       uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@<SHA>  # v2.0.12
 #       permissions:
 #         contents: read
 #         security-events: write  # required when upload-sarif: true (default)
+#         actions: read           # required by codeql-action/upload-sarif for run metadata
 #       secrets: inherit
 #
 # Design rationale: gosec+govulncheck live in their own reusable workflow
@@ -89,7 +90,7 @@ on:
         default: "./..."
 
       upload-sarif:
-        description: "Whether to upload SARIF findings to the GitHub Security tab. When true, the caller MUST grant 'security-events: write'."
+        description: "Whether to upload SARIF findings to the GitHub Security tab. When true, the caller MUST grant both 'security-events: write' (to upload SARIF) AND 'actions: read' (for codeql-action/upload-sarif to fetch workflow run metadata). Missing 'actions: read' surfaces as 'Resource not accessible by integration' on the upload step even when the scan succeeds."
         required: false
         type: boolean
         default: true
@@ -124,6 +125,13 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      # `codeql-action/upload-sarif` calls `GET /repos/{owner}/{repo}/actions/runs/{run_id}`
+      # to attach SARIF findings to the triggering workflow run (and for telemetry).
+      # Without `actions: read` the SARIF upload step errors with
+      # "Resource not accessible by integration" and the gosec job fails,
+      # even though the scan itself succeeded. See caligula/cato/florian
+      # security.yml runs on 2026-04-19 for the failure signature.
+      actions: read
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
@@ -165,6 +173,8 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      # Required by `codeql-action/upload-sarif`. See gosec job above for rationale.
+      actions: read
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}

--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@<SHA>  # v1.0.0
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@<SHA>  # v2.0.12
     permissions:
       contents: read
       security-events: write  # required when upload-sarif: true (default)
+      actions: read           # required by codeql-action/upload-sarif for run metadata
     secrets: inherit
 ```
 
@@ -114,7 +115,7 @@ jobs:
 | `enable-govulncheck` | `true` | Run govulncheck against the module |
 | `govulncheck-version` | `v1.1.4` | Pinned govulncheck module version |
 | `govulncheck-package` | `./...` | Package selector for govulncheck |
-| `upload-sarif` | `true` | Upload SARIF findings to the GitHub Security tab. When `true`, **the caller MUST grant `security-events: write`**. Set `false` to run as CI-only checks without publishing to the Security tab. |
+| `upload-sarif` | `true` | Upload SARIF findings to the GitHub Security tab. When `true`, **the caller MUST grant both `security-events: write` and `actions: read`**. Missing `actions: read` surfaces as "Resource not accessible by integration" on the upload step even though the scan itself succeeded — `codeql-action/upload-sarif` needs to fetch workflow run metadata. Set `false` to run as CI-only checks without publishing to the Security tab. |
 | `enable-harden-runner` | `true` | Install StepSecurity Harden-Runner as first step of every job |
 | `harden-runner-policy` | `audit` | `audit` (observe) or `block` (deny-by-default egress) |
 | `harden-runner-allowed-endpoints` | `""` | Newline-separated allowlist for block mode |


### PR DESCRIPTION
## Problem

Both `gosec` and `govulncheck` jobs' SARIF upload step was silently failing with:

```
##[error]Resource not accessible by integration - https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run
```

The scans themselves ran successfully, but the findings never reached the Security tab because `codeql-action/upload-sarif` needs to call `GET /repos/{owner}/{repo}/actions/runs/{run_id}` (for run metadata + telemetry), and the caller's job permissions (`contents: read, security-events: write`) didn't include `actions: read`.

Pre-existing bug, not a v2.0.11 regression — but surfaced clearly during today's drift sweep once every security.yml caller landed on the new SHA and started running uniformly.

## Reproduction

See the following v2.0.11 runs on 2026-04-19:
- [caligula run 24641570390](https://github.com/praetorian-inc/caligula/actions/runs/24641570390) — gosec + govulncheck both `[failure] Upload SARIF`
- [cato run 24641578866](https://github.com/praetorian-inc/cato/actions/runs/24641578866) — same pattern
- [florian run 24641559194](https://github.com/praetorian-inc/florian/actions/runs/24641559194) — same pattern

Affects **8 consumer repos** currently: augustus, caligula, cato, florian, julius, nerva, titus, vespasian.

## Fix

Add `actions: read` to both `gosec` and `govulncheck` job `permissions:` blocks in `go-security.yml`.

Because GitHub Actions permission cascade is **caller-intersection** (a reusable workflow's job can only hold permissions the caller granted), **callers must also grant `actions: read`** at their `security.yml` job-level `permissions:`. README + caller-example + input description updated to reflect that.

## Rollout

1. Merge this PR
2. Tag `v2.0.12`
3. Sweep the 8 security.yml callers in one pass:
   - Bump the reusable pin `@e7c1f39 (v2.0.11)` → `@<v2.0.12 SHA>`
   - Add `actions: read` to the `security:` job's permissions block

Combined diff per consumer: 2 lines (SHA + one new permission).

## Non-breaking

Callers that update: SARIF upload works → findings reach Security tab.
Callers that don't update: fail the same way they already fail today (SARIF upload step `[failure]`, but the rest of the job + scans still run). No behavior regression.