### PR TITLE
fix(claude-code): accept ready_for_review so draft PRs get Claude review

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -87,7 +87,8 @@ jobs:
       !contains(github.actor, 'coderabbit') && !contains(github.actor, 'devin') && !contains(github.actor, '[bot]') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (
-        (github.event_name == 'pull_request' && github.event.action == 'opened')
+        (github.event_name == 'pull_request'
+          && (github.event.action == 'opened' || github.event.action == 'ready_for_review'))
         ||
         (github.event_name == 'pull_request_review_comment'
           && contains(github.event.comment.body, '@claude'))
@@ -176,15 +177,22 @@ jobs:
     #     org members as CONTRIBUTOR). Forks always have a different head.repo.
     #     Closes the "comment and control" attack path (CVSS 9.4, oddguan.com).
     #   - `synchronize` (new commits) is INTENTIONALLY EXCLUDED. Claude reviews only
-    #     on first open. CodeRabbit + Codex handle per-push feedback. Developers
-    #     can force re-review via `@claude` on a PR review comment.
+    #     on first open (or draft→ready conversion). CodeRabbit + Codex handle
+    #     per-push feedback. Developers can force re-review via `@claude` on a PR
+    #     review comment.
+    #   - `ready_for_review` (draft→ready conversion) IS included. Without it, PRs
+    #     opened as drafts never get a Claude review — the `opened` event fires
+    #     while draft==true (skipped), and `ready_for_review` was not in the allow
+    #     list. Callers must also list `ready_for_review` in their
+    #     on.pull_request.types for GitHub to deliver the event.
     if: |
       needs.preflight.outputs.has_code == 'true' &&
       github.event.pull_request.draft == false &&
       !contains(github.actor, 'coderabbit') && !contains(github.actor, 'devin') && !contains(github.actor, '[bot]') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (
-        (github.event_name == 'pull_request' && github.event.action == 'opened')
+        (github.event_name == 'pull_request'
+          && (github.event.action == 'opened' || github.event.action == 'ready_for_review'))
         ||
         (github.event_name == 'pull_request_review_comment'
           && contains(github.event.comment.body, '@claude'))

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Runs Claude as a PR reviewer. **All security posture is hardcoded in the reusabl
 
 - **Same-repo-only gate**: `github.event.pull_request.head.repo.full_name == github.repository`. Fork PRs are blocked outright — stricter than the previously-used `author_association` check (which reports org members as `CONTRIBUTOR` on public repos and silently skipped runs, hit in v2.0.3-v2.0.5). Closes the CVSS 9.4 [comment-and-control](https://oddguan.com/blog/comment-and-control-prompt-injection-credential-theft-claude-code-gemini-cli-github-copilot/) attack path on both PR and review-comment triggers.
 - **Preflight job** skips Claude entirely on docs-only PRs (files matching `*.md / *.markdown / *.rst / *.txt / docs/** / LICENSE / .gitignore / CODEOWNERS / images`). Uses paginated `gh api pulls/N/files` (handles PRs >100 files per cli/cli#5368). `@claude` on a PR review comment bypasses the filter (documented override).
-- **Model hardcoded**: `--model claude-opus-4-7`. Claude runs once per PR (on `opened` only; `synchronize` is intentionally excluded — CodeRabbit + Codex already run on every push). Opus is paid 1x per PR for the highest-capability senior-engineer review.
+- **Model hardcoded**: `--model claude-opus-4-7`. Claude runs once per PR (on `opened` or `ready_for_review`; `synchronize` is intentionally excluded — CodeRabbit + Codex already run on every push). `ready_for_review` covers PRs opened as drafts — without it, the `opened` event fires while `draft==true` (skipped) and the PR never gets a Claude review. Opus is paid 1x per PR for the highest-capability senior-engineer review.
 - `--allowedTools "Bash(gh pr comment/diff/view:*), Read, Grep, Glob"` — the minimum surface needed to review a PR and post the top-level summary comment. Inline line-anchored commenting deliberately NOT included (CodeRabbit covers it).
 - `--disallowedTools` floor: explicitly denies `Bash(curl:*)`, `Bash(wget:*)`, `Bash(gh api:*)`, `Bash(gh auth:*)`, `Bash(git add|commit|push|rm:*)`, `Write`, `Edit`, `MultiEdit`. Defense-in-depth against [claude-code-action#860](https://github.com/anthropics/claude-code-action/issues/860) where `track_progress: true` would union-merge write tools into the allowlist.
 - Explicit `track_progress: "false"` on the action step.
@@ -160,7 +160,7 @@ name: Claude PR Assistant
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
   pull_request_review_comment:
     types: [created]
 
@@ -178,7 +178,7 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
-Note: `pull_request: types: [opened]` only — Claude reviews once per PR open. Developers re-request a review via `@claude` on a PR review comment. `synchronize` (commits pushed to a PR) does NOT re-trigger Claude by design.
+Note: `pull_request: types: [opened, ready_for_review]` — Claude reviews once per PR (on first open, or when a draft PR is marked ready). Developers re-request a review via `@claude` on a PR review comment. `synchronize` (commits pushed to a PR) does NOT re-trigger Claude by design.
 
 **Inputs** (all optional):
 


### PR DESCRIPTION
## Summary

- Adds `ready_for_review` to both `preflight` and `claude-code-action` job `if:` conditions
- Updates README caller template and docs to include the new event type
- PRs opened as drafts were silently skipping Claude review: the `opened` event fires while `draft==true` (blocked by the `if:` guard), and `ready_for_review` was not accepted

## Root cause

Discovered on [julius#75](https://github.com/praetorian-inc/julius/pull/75) — PR opened as draft, converted to ready, Claude never ran.

## Caller action required

After this merges, all 25 caller repos need to add `ready_for_review` to their `on.pull_request.types`. A batch PR will follow for all callers, also bumping to the new SHA.

## Test plan

- [ ] Merge this PR
- [ ] Update a caller repo (e.g., julius) to include `ready_for_review` in types and point at the new SHA
- [ ] Open a draft PR in that repo, mark it ready, confirm Claude runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)