### PR TITLE
fix(security): switch harden-runner to block mode on external-contrib workflow

### DIFF
--- a/.github/workflows/external-contrib-notify.yml
+++ b/.github/workflows/external-contrib-notify.yml
@@ -102,13 +102,16 @@ on:
         description: "Harden-Runner egress policy: 'audit' (observe + report) or 'block' (deny by default)."
         required: false
         type: string
-        default: "audit"
+        default: "block"
 
       harden-runner-allowed-endpoints:
-        description: "Newline-separated allowed egress endpoints when harden-runner-policy=block. Ignored in audit mode. Recommended for block mode: api.github.com:443, api.linear.app:443, slack.com:443, hooks.slack.com:443."
+        description: "Newline-separated allowed egress endpoints when harden-runner-policy=block. Ignored in audit mode."
         required: false
         type: string
-        default: ""
+        default: >-
+          api.github.com:443
+          api.linear.app:443
+          slack.com:443
 
     secrets:
       EXTERNAL_CONTRIB_APP_ID:


### PR DESCRIPTION
## Summary
- Switches Harden-Runner from `audit` to `block` mode on the `external-contrib-notify.yml` reusable workflow
- Adds a narrow egress allowlist: `api.github.com:443`, `api.linear.app:443`, `slack.com:443`
- These are the only 3 endpoints the `external-contrib-action` calls, confirmed by source code audit of all TypeScript in `praetorian-inc/external-contrib-action@v3.0.0`

## Why
The `pull_request_target` trigger runs with base-repo secrets and write permissions on external PRs — making it the highest-risk CI/CD trigger. While the workflow already avoids checking out PR code (eliminating the primary attack vector), switching to block mode adds defense-in-depth: if the action or its dependencies were ever compromised, egress is limited to 3 known endpoints, preventing secret exfiltration.

All 18 caller repos (capability repos + others) inherit this change automatically since none override the `harden-runner-policy` or `harden-runner-allowed-endpoints` inputs.

## Test plan
- [ ] Verify a real external contribution (or simulated one) on a test repo still triggers Linear issue creation, Slack notification, and GitHub auto-reply
- [ ] Confirm Harden-Runner logs show `block` mode with only the 3 allowed endpoints
- [ ] Verify no `ECONNREFUSED` or DNS resolution failures in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)