### PR TITLE
fix(codex): authenticate pre-fetch for private repos

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -208,8 +208,17 @@ jobs:
         env:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git fetch --no-tags origin "$PR_BASE_REF" "+refs/pull/$PR_NUMBER/head"
+          set -eu
+          # Use a one-shot auth header via git -c (memory-only, NOT written to
+          # .git/config) so the fetch authenticates against private repos while
+          # persist-credentials: false is preserved. By the time the Codex
+          # sandbox starts in the next step, this token is gone from both disk
+          # and process memory.
+          AUTH="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 -w0)"
+          git -c "http.https://github.com/.extraheader=$AUTH" \
+            fetch --no-tags origin "$PR_BASE_REF" "+refs/pull/$PR_NUMBER/head"
 
       - name: Run Codex
         id: run_codex


### PR DESCRIPTION
## Summary
- Fixes Codex PR review failing on all private repos with `fatal: could not read Username for 'https://github.com': No such device or address`
- Root cause: `persist-credentials: false` on the checkout step strips the GITHUB_TOKEN from git config, so the subsequent `git fetch` in the pre-fetch step can't authenticate
- Fix: inject a one-shot auth header via `git -c` (memory-only, NOT written to `.git/config`)

## Security analysis
The most secure option — preserves all five defense-in-depth layers:

| Layer | Status | Detail |
|-------|--------|--------|
| `persist-credentials: false` | **Preserved** | `git -c` is memory-only, nothing written to `.git/config` |
| `sandbox: read-only` | Unchanged | Codex cannot write files |
| `safety-strategy: drop-sudo` | Unchanged | Blocks `/proc/*/environ` access |
| `contents: read` permissions | Unchanged | No write access to repo or PRs |
| Separate `post-feedback` job | Unchanged | PR writes isolated from sandbox |

The GITHUB_TOKEN exists only in the pre-fetch step's process memory. By the time Codex starts in the next step, the token is gone from both disk and process memory.

Alternative considered: removing `persist-credentials: false` — rejected because it would leave the GITHUB_TOKEN in `.git/config` on disk during the Codex sandbox execution, weakening defense-in-depth if `drop-sudo` is ever bypassed.

## Test plan
- [ ] Verify Codex review succeeds on a private repo PR (e.g., re-run on one of the 19 pinning PRs)
- [ ] Verify `.git/config` does NOT contain any auth headers after the pre-fetch step
- [ ] Verify docs-only PRs still skip via preflight

🤖 Generated with [Claude Code](https://claude.com/claude-code)