### PR TITLE
fix(unit-tests): harden reusable workflow against CI/CD supply-chain risks

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,22 @@ name: Unit Tests (Callable)
 
 on:
   workflow_call:
+    inputs:
+      enable-harden-runner:
+        description: "Enable step-security/harden-runner"
+        type: boolean
+        default: true
+        required: false
+      harden-runner-policy:
+        description: "Harden-runner egress policy (audit or block)"
+        type: string
+        default: "audit"
+        required: false
+      harden-runner-allowed-endpoints:
+        description: "Newline-separated allowed endpoints for block mode"
+        type: string
+        default: ""
+        required: false
     secrets:
       PLUGIN_CI_APP_ID:
         description: "GitHub App ID for private dependency access (contents:read)"
@@ -10,12 +26,22 @@ on:
         description: "GitHub App private key for private dependency access"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - name: Harden runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -29,10 +55,12 @@ jobs:
           repositories: claude-tool-sdk
 
       - name: Configure git for private dependencies
+        env:
+          GIT_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
-          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "ssh://git@github.com/"
-          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/".insteadOf "git@github.com:"
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:


### PR DESCRIPTION
## Summary
- Fix token interpolation in shell (Critical — anti-pattern A13/A14)
- Add missing `permissions: contents: read` (High)  
- Pin `ubuntu-24.04`, add Harden-Runner, bump checkout to v6.0.2

## Security controls added
- `env:` + shell-var pattern for GitHub App token (prevents debug-log leak)
- Workflow-level `permissions: contents: read` ceiling
- `step-security/harden-runner` with configurable egress policy
- Pinned OS image (`ubuntu-24.04`)

## Verified safe
- `permissions: contents: read` — checkout only needs read; `create-github-app-token` doesn't use GITHUB_TOKEN
- `ubuntu-24.04` — confirmed available as standard GitHub runner
- Token masking — `create-github-app-token` docs: "The token is masked, it cannot be logged accidentally"
- Harden-Runner `if:` syntax — uses `${{ inputs.enable-harden-runner }}` matching repo convention

## Test plan
- [ ] Caller repo CI passes with this reusable (checkout + npm test still work)
- [ ] Harden-Runner audit log appears in job output
- [ ] Token is not visible in job logs even with ACTIONS_STEP_DEBUG

🤖 Generated with [Claude Code](https://claude.ai/claude-code)