### PR TITLE
fix(ts-ci): lint step now fails on real lint errors

### DIFF
--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -260,10 +260,10 @@ jobs:
       - name: Lint
         working-directory: ${{ inputs.working-directory }}
         run: |
-          if npm run lint --if-present 2>/dev/null; then
-            echo "Lint passed"
+          if jq -e '.scripts.lint' package.json > /dev/null 2>&1; then
+            npm run lint
           else
-            echo "No lint script found or lint not configured — skipping"
+            echo "No lint script in package.json — skipping"
           fi
 
   test:


### PR DESCRIPTION
## Summary
The lint step was using `npm run lint --if-present 2>/dev/null` which silently swallowed real lint failures. Now uses `jq` to check if the script exists, then runs it without suppression.

| Scenario | Before | After |
|----------|--------|-------|
| No lint script | Skip (correct) | Skip (correct) |
| Lint passes | Pass (correct) | Pass (correct) |
| Lint fails | **Silent pass (wrong)** | **CI fails (correct)** |

## Test plan
- [ ] `test-ts-ci.yml` self-test passes (fixture has `"lint": "echo 'no lint configured'"` which exits 0)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)