### PR TITLE
fix(ts-ci): remove setup-node cache that fails on workspace repos

### DIFF
--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -160,8 +160,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: npm
-          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
 
       - name: Install dependencies
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## Summary
`actions/setup-node` with `cache: npm` + `cache-dependency-path` fails on repos with npm workspaces (like `praetorian-core-plugin`) with:
```
Some specified paths were not resolved, unable to cache dependencies.
```

The setup-node built-in cache is redundant — we already cache `node_modules` + `~/.npm` via `actions/cache/save` and `actions/cache/restore` across all jobs.

**Root cause:** Discovered via CI failure on https://github.com/praetorian-inc/praetorian-core/pull/149

## Test plan
- [ ] `test-ts-ci.yml` self-test passes
- [ ] praetorian-core PR #149 passes after SHA bump to this fix

🤖 Generated with [Claude Code](https://claude.ai/claude-code)