### PR TITLE
fix(security): harden version-check.yml — permissions, egress control, pinned deps

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,14 +1,44 @@
 name: Version Check (Callable)
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      enable-harden-runner:
+        description: "Whether to install StepSecurity Harden-Runner as the first step."
+        required: false
+        type: boolean
+        default: true
+
+      harden-runner-policy:
+        description: "Harden-Runner egress policy: 'audit' (observe + report) or 'block' (deny by default)."
+        required: false
+        type: string
+        default: "audit"
+
+      harden-runner-allowed-endpoints:
+        description: "Newline-separated allowed egress endpoints when harden-runner-policy=block. Ignored in audit mode."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
 
 jobs:
   version-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## Summary
Four hardening fixes to `version-check.yml`, batched so consumer repos bump once:

1. **Add permissions block (Medium)** — This was the only reusable workflow with zero permissions declaration. Added workflow-level + per-job `contents: read` for explicit least-privilege.

2. **Add Harden-Runner (Medium)** — Only non-test reusable without Harden-Runner. Added configurable egress control (v2.19.0, audit default) for consistency with every other reusable in this repo.

3. **Pin runner OS (High)** — `runs-on: ubuntu-latest` → `ubuntu-24.04` (anti-pattern A17).

4. **Bump actions/checkout (High)** — v4.3.1 → v6.0.2. Was two major versions behind.

Completes the version-workflow hardening trilogy: version-bump (#47, merged), version-set (#48), version-check (this PR).

## Test plan
- [ ] Open a PR in a consumer repo — verify version-check still passes after version-bump runs
- [ ] Confirm Harden-Runner appears in the job log (audit mode)
- [ ] Verify the new inputs are backwards-compatible (callers that don't pass them get defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)