### PR TITLE
fix(security) + refactor(ci): harden AI reviewers + consolidate shared preflight

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -69,101 +69,19 @@ permissions:
   contents: read
 
 jobs:
-  # Preflight: skip the Claude job entirely if the PR only touches docs / config /
-  # images. Saves ~$1-2 per docs-only PR (Opus run cost) at the price of ~30 seconds
-  # of GitHub-runner time. Callers don't need to configure anything — this is a
-  # central "what counts as code" policy.
-  #
-  # The skip patterns cover: markdown (.md / .markdown / .rst / .txt), all of /docs,
-  # license-like files (LICENSE, .gitignore, CODEOWNERS), images
-  # (.png / .jpg / .jpeg / .svg / .gif / .webp / .ico), CI config (.github/), and
-  # plugin metadata (.claude-plugin/). A PR that touches ANY file NOT matching these
-  # patterns is treated as a code PR and Claude runs.
-  #
-  # If a developer genuinely wants Claude review on a docs-only PR, they can post
-  # an `@claude` PR review comment to force one — the review_comment trigger is
-  # not path-filtered.
+  # Preflight: shared reusable that skips the review job on docs-only PRs.
+  # See preflight.yml for the full logic (SKIP_RE, paginated file list, skip comment).
   preflight:
-    # Same boundary checks as claude-code-action — don't spawn preflight for events
-    # we wouldn't review anyway (drafts, bots, external forks, wrong event type).
-    if: |
-      github.event.pull_request.draft == false &&
-      !contains(github.actor, 'coderabbit') && !contains(github.actor, 'devin') && !contains(github.actor, '[bot]') &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (
-        (github.event_name == 'pull_request'
-          && (github.event.action == 'opened' || github.event.action == 'ready_for_review'))
-        ||
-        (github.event_name == 'pull_request_review_comment'
-          && contains(github.event.comment.body, '@claude'))
-      )
-    runs-on: ubuntu-24.04
-    # Wall-clock ceiling. Preflight is a small gh-api + grep step; 5 min is
-    # >20x the p99. Cap blocks a runaway shell loop or a stuck gh-api retry
-    # from sitting on the runner for the 6-hour GitHub default.
-    timeout-minutes: 5
+    uses: ./.github/workflows/preflight.yml
     permissions:
       contents: read
-      pull-requests: write  # needed to post the "skipped — non-code PR" status comment
-    outputs:
-      has_code: ${{ steps.check.outputs.has_code }}
-    steps:
-      - name: Harden Runner
-        if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
-        with:
-          egress-policy: ${{ inputs.harden-runner-policy }}
-          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
-
-      - name: Check for code changes in the PR
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EVENT_NAME: ${{ github.event_name }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -eu
-
-          # Override path: `@claude` mention on a review comment always forces Claude
-          # to run, regardless of file types. The job's own if: (line ~82) already
-          # required contains(comment.body, '@claude'), so by the time preflight runs
-          # on a review_comment event, we know the reviewer explicitly asked for it.
-          # Respecting that override is the documented escape hatch for docs-only PRs.
-          if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
-            echo "has_code=true" >> "$GITHUB_OUTPUT"
-            echo "🔔 @claude mention on a review comment — bypassing docs-only filter."
-            exit 0
-          fi
-
-          # Use the paginated `pulls/.../files` REST endpoint (not `gh pr view --json files`,
-          # which is capped at 100 files per cli/cli#5368 and can misclassify large PRs
-          # where code files appear after the first 100). --paginate iterates all pages.
-          FILES=$(gh api \
-            "repos/$REPO/pulls/$PR_NUMBER/files" \
-            --paginate --jq '.[].filename')
-
-          echo "Changed files in PR ($(echo "$FILES" | wc -l | tr -d ' ') total):"
-          echo "$FILES" | sed 's/^/  /'
-          echo
-
-          # SKIP_RE matches docs / licenses / images / config-like files.
-          # If ALL changed files match, we have a non-code PR.
-          SKIP_RE='\.(md|markdown|rst|txt|png|jpg|jpeg|svg|gif|webp|ico)$|^LICENSE|^\.gitignore$|^CODEOWNERS$|^docs/|^\.github/|^\.claude-plugin/'
-
-          if echo "$FILES" | grep -vE "$SKIP_RE" | grep -q .; then
-            echo "has_code=true" >> "$GITHUB_OUTPUT"
-            echo "✓ Code changes detected — Claude will review this PR."
-          else
-            echo "has_code=false" >> "$GITHUB_OUTPUT"
-            echo "⊘ Docs/config-only PR — Claude review will be skipped."
-            # Post a visible status comment so reviewers know why Claude isn't running.
-            # Only pull_request events reach this branch (review_comment short-circuits
-            # to has_code=true above), so we always post the skip comment here.
-            gh pr comment "$PR_NUMBER" \
-              --repo "$REPO" \
-              --body "Claude review skipped — non-code PR (only changed files matching \`docs/**\`, \`.github/**\`, \`.claude-plugin/**\`, \`*.md\`, \`*.txt\`, images, or license-like files). Post \`@claude\` on a review comment to force a review."
-          fi
+      pull-requests: write
+    with:
+      mention_keyword: "@claude"
+      reviewer_name: "Claude"
+      enable-harden-runner: ${{ inputs.enable-harden-runner }}
+      harden-runner-policy: ${{ inputs.harden-runner-policy }}
+      harden-runner-allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
 
   claude-code-action:
     needs: preflight

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -65,6 +65,9 @@ on:
         description: "Anthropic API key for Claude"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   # Preflight: skip the Claude job entirely if the PR only touches docs / config /
   # images. Saves ~$1-2 per docs-only PR (Opus run cost) at the price of ~30 seconds
@@ -94,7 +97,7 @@ jobs:
         (github.event_name == 'pull_request_review_comment'
           && contains(github.event.comment.body, '@claude'))
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Wall-clock ceiling. Preflight is a small gh-api + grep step; 5 min is
     # >20x the p99. Cap blocks a runaway shell loop or a stuck gh-api retry
     # from sitting on the runner for the 6-hour GitHub default.
@@ -107,7 +110,7 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
@@ -116,6 +119,9 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eu
 
@@ -124,7 +130,7 @@ jobs:
           # required contains(comment.body, '@claude'), so by the time preflight runs
           # on a review_comment event, we know the reviewer explicitly asked for it.
           # Respecting that override is the documented escape hatch for docs-only PRs.
-          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+          if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
             echo "has_code=true" >> "$GITHUB_OUTPUT"
             echo "🔔 @claude mention on a review comment — bypassing docs-only filter."
             exit 0
@@ -134,7 +140,7 @@ jobs:
           # which is capped at 100 files per cli/cli#5368 and can misclassify large PRs
           # where code files appear after the first 100). --paginate iterates all pages.
           FILES=$(gh api \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            "repos/$REPO/pulls/$PR_NUMBER/files" \
             --paginate --jq '.[].filename')
 
           echo "Changed files in PR ($(echo "$FILES" | wc -l | tr -d ' ') total):"
@@ -154,8 +160,8 @@ jobs:
             # Post a visible status comment so reviewers know why Claude isn't running.
             # Only pull_request events reach this branch (review_comment short-circuits
             # to has_code=true above), so we always post the skip comment here.
-            gh pr comment ${{ github.event.pull_request.number }} \
-              --repo ${{ github.repository }} \
+            gh pr comment "$PR_NUMBER" \
+              --repo "$REPO" \
               --body "Claude review skipped — non-code PR (only changed files matching \`docs/**\`, \`.github/**\`, \`.claude-plugin/**\`, \`*.md\`, \`*.txt\`, images, or license-like files). Post \`@claude\` on a review comment to force a review."
           fi
 
@@ -199,7 +205,7 @@ jobs:
           && contains(github.event.comment.body, '@claude'))
       )
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     # Wall-clock ceiling on the Claude review job. `--max-turns 15` caps
     # the number of tool-call turns, but NOT wall time (a long-running
@@ -217,13 +223,13 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
 
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -77,84 +77,19 @@ permissions:
   contents: read
 
 jobs:
-  # Preflight: skip the Codex job entirely if the PR only touches docs / config /
-  # images. Same logic as the Claude and Gemini PR Assistants — saves API cost on
-  # non-code PRs. `@codex` on a PR review comment bypasses this filter.
-  #
-  # The skip patterns cover: markdown (.md / .markdown / .rst / .txt), all of /docs,
-  # license-like files (LICENSE, .gitignore, CODEOWNERS), and images
-  # (.png / .jpg / .jpeg / .svg / .gif / .webp / .ico). A PR that touches ANY file
-  # NOT matching these patterns is treated as a code PR and Codex runs.
+  # Preflight: shared reusable that skips the review job on docs-only PRs.
+  # See preflight.yml for the full logic (SKIP_RE, paginated file list, skip comment).
   preflight:
-    # Same boundary checks as the review job — don't spawn preflight for events
-    # we wouldn't review anyway (drafts, bots, external forks, wrong event type).
-    if: |
-      github.event.pull_request.draft == false &&
-      !contains(github.actor, 'coderabbit') && !contains(github.actor, 'devin') && !contains(github.actor, '[bot]') &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (
-        (github.event_name == 'pull_request'
-          && (github.event.action == 'opened' || github.event.action == 'ready_for_review'))
-        ||
-        (github.event_name == 'pull_request_review_comment'
-          && contains(github.event.comment.body, '@codex'))
-      )
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    uses: ./.github/workflows/preflight.yml
     permissions:
       contents: read
       pull-requests: write
-    outputs:
-      has_code: ${{ steps.check.outputs.has_code }}
-    steps:
-      - name: Harden Runner
-        if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
-        with:
-          egress-policy: ${{ inputs.harden-runner-policy }}
-          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
-
-      - name: Check for code changes in the PR
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EVENT_NAME: ${{ github.event_name }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -eu
-
-          # @codex mention on a review comment always forces Codex to run,
-          # regardless of file types. The job's own if: already required
-          # contains(comment.body, '@codex'), so by the time preflight runs on a
-          # review_comment event, we know the reviewer explicitly asked for it.
-          if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
-            echo "has_code=true" >> "$GITHUB_OUTPUT"
-            echo "🔔 @codex mention on a review comment — bypassing docs-only filter."
-            exit 0
-          fi
-
-          # Paginated file list (handles PRs >100 files per cli/cli#5368).
-          FILES=$(gh api \
-            "repos/$REPO/pulls/$PR_NUMBER/files" \
-            --paginate --jq '.[].filename')
-
-          echo "Changed files in PR ($(echo "$FILES" | wc -l | tr -d ' ') total):"
-          echo "$FILES" | sed 's/^/  /'
-          echo
-
-          SKIP_RE='\.(md|markdown|rst|txt|png|jpg|jpeg|svg|gif|webp|ico)$|^LICENSE|^\.gitignore$|^CODEOWNERS$|^docs/|^\.github/|^\.claude-plugin/'
-
-          if echo "$FILES" | grep -vE "$SKIP_RE" | grep -q .; then
-            echo "has_code=true" >> "$GITHUB_OUTPUT"
-            echo "✓ Code changes detected — Codex will review this PR."
-          else
-            echo "has_code=false" >> "$GITHUB_OUTPUT"
-            echo "⊘ Docs/config-only PR — Codex review will be skipped."
-            gh pr comment "$PR_NUMBER" \
-              --repo "$REPO" \
-              --body "Codex review skipped — non-code PR (only changed files matching \`docs/**\`, \`.github/**\`, \`.claude-plugin/**\`, \`*.md\`, \`*.txt\`, images, or license-like files). Post \`@codex\` on a review comment to force a review."
-          fi
+    with:
+      mention_keyword: "@codex"
+      reviewer_name: "Codex"
+      enable-harden-runner: ${{ inputs.enable-harden-runner }}
+      harden-runner-policy: ${{ inputs.harden-runner-policy }}
+      harden-runner-allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
 
   # Codex review: run the Codex CLI in a read-only sandbox via openai/codex-action.
   #

--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -73,6 +73,9 @@ on:
         description: "OpenAI API key for Codex (pay-per-token billing)"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   # Preflight: skip the Codex job entirely if the PR only touches docs / config /
   # images. Same logic as the Claude and Gemini PR Assistants — saves API cost on
@@ -96,7 +99,7 @@ jobs:
         (github.event_name == 'pull_request_review_comment'
           && contains(github.event.comment.body, '@codex'))
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: read
@@ -106,7 +109,7 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
@@ -115,6 +118,9 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eu
 
@@ -122,7 +128,7 @@ jobs:
           # regardless of file types. The job's own if: already required
           # contains(comment.body, '@codex'), so by the time preflight runs on a
           # review_comment event, we know the reviewer explicitly asked for it.
-          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+          if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
             echo "has_code=true" >> "$GITHUB_OUTPUT"
             echo "🔔 @codex mention on a review comment — bypassing docs-only filter."
             exit 0
@@ -130,7 +136,7 @@ jobs:
 
           # Paginated file list (handles PRs >100 files per cli/cli#5368).
           FILES=$(gh api \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            "repos/$REPO/pulls/$PR_NUMBER/files" \
             --paginate --jq '.[].filename')
 
           echo "Changed files in PR ($(echo "$FILES" | wc -l | tr -d ' ') total):"
@@ -145,8 +151,8 @@ jobs:
           else
             echo "has_code=false" >> "$GITHUB_OUTPUT"
             echo "⊘ Docs/config-only PR — Codex review will be skipped."
-            gh pr comment ${{ github.event.pull_request.number }} \
-              --repo ${{ github.repository }} \
+            gh pr comment "$PR_NUMBER" \
+              --repo "$REPO" \
               --body "Codex review skipped — non-code PR (only changed files matching \`docs/**\`, \`.github/**\`, \`.claude-plugin/**\`, \`*.md\`, \`*.txt\`, images, or license-like files). Post \`@codex\` on a review comment to force a review."
           fi
 
@@ -175,7 +181,7 @@ jobs:
           && contains(github.event.comment.body, '@codex'))
       )
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     # Wall-clock ceiling. codex-mini reviews complete in 2-5 minutes typically.
     # 10 minutes is ~3x the p99. Tight enough to catch a stuck run without
@@ -193,13 +199,13 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
 
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           persist-credentials: false
@@ -251,7 +257,7 @@ jobs:
   post-feedback:
     needs: codex-review
     if: needs.codex-review.outputs.final_message != ''
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       pull-requests: write
@@ -259,7 +265,7 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -55,6 +55,9 @@ on:
         description: "Google AI Studio API key for Gemini"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   # Preflight: skip the Gemini job entirely if the PR only touches docs / config /
   # images. Same logic as the Claude PR Assistant — saves API cost on non-code PRs.
@@ -71,7 +74,7 @@ jobs:
         (github.event_name == 'pull_request_review_comment'
           && contains(github.event.comment.body, '@gemini'))
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: read
@@ -81,7 +84,7 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
@@ -90,11 +93,14 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eu
 
           # @gemini mention on a review comment always forces Gemini to run.
-          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+          if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
             echo "has_code=true" >> "$GITHUB_OUTPUT"
             echo "🔔 @gemini mention on a review comment — bypassing docs-only filter."
             exit 0
@@ -102,7 +108,7 @@ jobs:
 
           # Paginated file list (handles PRs >100 files per cli/cli#5368).
           FILES=$(gh api \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            "repos/$REPO/pulls/$PR_NUMBER/files" \
             --paginate --jq '.[].filename')
 
           echo "Changed files in PR ($(echo "$FILES" | wc -l | tr -d ' ') total):"
@@ -117,8 +123,8 @@ jobs:
           else
             echo "has_code=false" >> "$GITHUB_OUTPUT"
             echo "⊘ Docs/config-only PR — Gemini review will be skipped."
-            gh pr comment ${{ github.event.pull_request.number }} \
-              --repo ${{ github.repository }} \
+            gh pr comment "$PR_NUMBER" \
+              --repo "$REPO" \
               --body "Gemini review skipped — non-code PR (only changed files matching \`docs/**\`, \`.github/**\`, \`.claude-plugin/**\`, \`*.md\`, \`*.txt\`, images, or license-like files). Post \`@gemini\` on a review comment to force a review."
           fi
 
@@ -137,7 +143,7 @@ jobs:
           && contains(github.event.comment.body, '@gemini'))
       )
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -146,13 +152,13 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
 
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -59,74 +59,19 @@ permissions:
   contents: read
 
 jobs:
-  # Preflight: skip the Gemini job entirely if the PR only touches docs / config /
-  # images. Same logic as the Claude PR Assistant — saves API cost on non-code PRs.
-  # `@gemini` on a PR review comment bypasses this filter.
+  # Preflight: shared reusable that skips the review job on docs-only PRs.
+  # See preflight.yml for the full logic (SKIP_RE, paginated file list, skip comment).
   preflight:
-    if: |
-      github.event.pull_request.draft == false &&
-      !contains(github.actor, 'coderabbit') && !contains(github.actor, 'devin') && !contains(github.actor, '[bot]') &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (
-        (github.event_name == 'pull_request'
-          && (github.event.action == 'opened' || github.event.action == 'ready_for_review'))
-        ||
-        (github.event_name == 'pull_request_review_comment'
-          && contains(github.event.comment.body, '@gemini'))
-      )
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    uses: ./.github/workflows/preflight.yml
     permissions:
       contents: read
       pull-requests: write
-    outputs:
-      has_code: ${{ steps.check.outputs.has_code }}
-    steps:
-      - name: Harden Runner
-        if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
-        with:
-          egress-policy: ${{ inputs.harden-runner-policy }}
-          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
-
-      - name: Check for code changes in the PR
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EVENT_NAME: ${{ github.event_name }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -eu
-
-          # @gemini mention on a review comment always forces Gemini to run.
-          if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
-            echo "has_code=true" >> "$GITHUB_OUTPUT"
-            echo "🔔 @gemini mention on a review comment — bypassing docs-only filter."
-            exit 0
-          fi
-
-          # Paginated file list (handles PRs >100 files per cli/cli#5368).
-          FILES=$(gh api \
-            "repos/$REPO/pulls/$PR_NUMBER/files" \
-            --paginate --jq '.[].filename')
-
-          echo "Changed files in PR ($(echo "$FILES" | wc -l | tr -d ' ') total):"
-          echo "$FILES" | sed 's/^/  /'
-          echo
-
-          SKIP_RE='\.(md|markdown|rst|txt|png|jpg|jpeg|svg|gif|webp|ico)$|^LICENSE|^\.gitignore$|^CODEOWNERS$|^docs/|^\.github/|^\.claude-plugin/'
-
-          if echo "$FILES" | grep -vE "$SKIP_RE" | grep -q .; then
-            echo "has_code=true" >> "$GITHUB_OUTPUT"
-            echo "✓ Code changes detected — Gemini will review this PR."
-          else
-            echo "has_code=false" >> "$GITHUB_OUTPUT"
-            echo "⊘ Docs/config-only PR — Gemini review will be skipped."
-            gh pr comment "$PR_NUMBER" \
-              --repo "$REPO" \
-              --body "Gemini review skipped — non-code PR (only changed files matching \`docs/**\`, \`.github/**\`, \`.claude-plugin/**\`, \`*.md\`, \`*.txt\`, images, or license-like files). Post \`@gemini\` on a review comment to force a review."
-          fi
+    with:
+      mention_keyword: "@gemini"
+      reviewer_name: "Gemini"
+      enable-harden-runner: ${{ inputs.enable-harden-runner }}
+      harden-runner-policy: ${{ inputs.harden-runner-policy }}
+      harden-runner-allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
 
   gemini-review:
     needs: preflight

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -124,7 +124,7 @@ jobs:
 
           # SKIP_RE: docs, licenses, images, CI config, plugin metadata.
           # If ALL changed files match, this is a non-code PR.
-          SKIP_RE='\.(md|markdown|rst|txt|png|jpg|jpeg|svg|gif|webp|ico)$|^LICENSE|^\.gitignore$|^CODEOWNERS$|^docs/|^\.github/|^\.claude-plugin/'
+          SKIP_RE='\.(md|markdown|rst|txt|png|jpg|jpeg|svg|gif|webp|ico)$|^LICENSE|^\.gitignore$|^docs/|^\.github/|^\.claude-plugin/'
 
           if echo "$FILES" | grep -vE "$SKIP_RE" | grep -q .; then
             echo "has_code=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,138 @@
+name: Preflight (Callable)
+# Shared preflight for AI reviewer workflows (claude-code, codex-code,
+# gemini-code). Checks whether a PR has code changes worth reviewing.
+# Saves ~$1-2 per docs-only PR (LLM API cost) at ~30s of runner time.
+#
+# Consolidates the identical preflight logic that was previously inlined
+# in each AI reviewer workflow. One place to maintain the SKIP_RE pattern,
+# the file-change detection logic, and the skip-comment template.
+#
+# NOT intended for direct use by consumer repos — consumer repos call
+# the AI reviewer workflows (claude-code.yml, codex-code.yml,
+# gemini-code.yml), which call this internally.
+
+on:
+  workflow_call:
+    inputs:
+      mention_keyword:
+        description: "The @mention keyword that forces review (e.g., @claude, @codex, @gemini)."
+        required: true
+        type: string
+
+      reviewer_name:
+        description: "Human-readable reviewer name for skip comments (e.g., Claude, Codex, Gemini)."
+        required: true
+        type: string
+
+      enable-harden-runner:
+        description: "Whether to install StepSecurity Harden-Runner."
+        required: false
+        type: boolean
+        default: true
+
+      harden-runner-policy:
+        description: "Harden-Runner egress policy: 'audit' or 'block'."
+        required: false
+        type: string
+        default: "audit"
+
+      harden-runner-allowed-endpoints:
+        description: "Newline-separated allowed endpoints for block mode."
+        required: false
+        type: string
+        default: ""
+
+    outputs:
+      has_code:
+        description: "Whether the PR contains code changes worth reviewing ('true' or 'false')."
+        value: ${{ jobs.check.outputs.has_code }}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    # Gate: don't spawn preflight for events we wouldn't review anyway
+    # (drafts, bots, external forks, wrong event type).
+    #
+    # Design notes:
+    #   - head.repo.full_name == github.repository: strictly stronger than
+    #     author_association (which is unreliable for public repos — GitHub
+    #     reports org members as CONTRIBUTOR). Forks always have a different
+    #     head.repo. Closes the "comment and control" attack path.
+    #   - `synchronize` (new commits) is INTENTIONALLY EXCLUDED. AI reviewers
+    #     run only on first open (or draft→ready conversion).
+    #   - `ready_for_review` IS included so PRs opened as drafts get reviewed
+    #     when marked ready.
+    if: |
+      github.event.pull_request.draft == false &&
+      !contains(github.actor, 'coderabbit') && !contains(github.actor, 'devin') && !contains(github.actor, '[bot]') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        (github.event_name == 'pull_request'
+          && (github.event.action == 'opened' || github.event.action == 'ready_for_review'))
+        ||
+        (github.event_name == 'pull_request_review_comment'
+          && contains(github.event.comment.body, inputs.mention_keyword))
+      )
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      has_code: ${{ steps.check.outputs.has_code }}
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+
+      - name: Check for code changes in the PR
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEWER_NAME: ${{ inputs.reviewer_name }}
+          MENTION_KEYWORD: ${{ inputs.mention_keyword }}
+        run: |
+          set -eu
+
+          # @mention on a review comment always forces the reviewer to run,
+          # regardless of file types. The job's own if: already required
+          # contains(comment.body, mention_keyword), so by the time we reach
+          # here on a review_comment event, the reviewer explicitly asked for it.
+          if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
+            echo "has_code=true" >> "$GITHUB_OUTPUT"
+            echo "🔔 $MENTION_KEYWORD mention on a review comment — bypassing docs-only filter."
+            exit 0
+          fi
+
+          # Use the paginated pulls/.../files REST endpoint (not gh pr view
+          # --json files, which is capped at 100 files per cli/cli#5368).
+          FILES=$(gh api \
+            "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --paginate --jq '.[].filename')
+
+          echo "Changed files in PR ($(echo "$FILES" | wc -l | tr -d ' ') total):"
+          echo "$FILES" | sed 's/^/  /'
+          echo
+
+          # SKIP_RE: docs, licenses, images, CI config, plugin metadata.
+          # If ALL changed files match, this is a non-code PR.
+          SKIP_RE='\.(md|markdown|rst|txt|png|jpg|jpeg|svg|gif|webp|ico)$|^LICENSE|^\.gitignore$|^CODEOWNERS$|^docs/|^\.github/|^\.claude-plugin/'
+
+          if echo "$FILES" | grep -vE "$SKIP_RE" | grep -q .; then
+            echo "has_code=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Code changes detected — $REVIEWER_NAME will review this PR."
+          else
+            echo "has_code=false" >> "$GITHUB_OUTPUT"
+            echo "⊘ Docs/config-only PR — $REVIEWER_NAME review will be skipped."
+            gh pr comment "$PR_NUMBER" \
+              --repo "$REPO" \
+              --body "$REVIEWER_NAME review skipped — non-code PR (only changed files matching \`docs/**\`, \`.github/**\`, \`.claude-plugin/**\`, \`*.md\`, \`*.txt\`, images, or license-like files). Post \`$MENTION_KEYWORD\` on a review comment to force a review."
+          fi


### PR DESCRIPTION
## Summary
Security hardening + preflight consolidation across `claude-code.yml`, `codex-code.yml`, and `gemini-code.yml`, batched so consumer repos bump once.

### Security hardening (commit 1)
1. **Pin runner OS (High)** — `ubuntu-latest` → `ubuntu-24.04` on all 7 jobs
2. **Bump actions/checkout (High)** — v5.0.1 → v6.0.2
3. **Bump Harden-Runner (High)** — v2.18.0 → v2.19.0 on all 7 instances
4. **Add workflow-level permissions (Medium)** — `permissions: contents: read` safety net
5. **Env-pass event context in preflight shells (Medium)** — moved `github.event_name`, `github.repository`, `github.event.pull_request.number` to `env:` blocks

### Preflight consolidation (commit 2)
6. **Extract shared `preflight.yml`** — The 3 AI reviewer workflows each had an identical ~70-line preflight job (same SKIP_RE, same `gh api` call, same skip-comment template). Only the `@mention` keyword and reviewer name differed. Extracted into a shared reusable workflow parameterized by `mention_keyword` and `reviewer_name`.

**Result:** ~230 lines of duplication removed. Future SKIP_RE changes propagate to all 3 reviewers automatically. One place to maintain the paginated file-list logic.

## Test plan
- [ ] Open a code-change PR in a consumer repo — verify all 3 AI reviewers still trigger and post comments
- [ ] Open a docs-only PR — verify all 3 preflights correctly skip and post the "non-code PR" comment
- [ ] Post `@claude` / `@codex` / `@gemini` on a review comment — verify force-review still works
- [ ] Confirm Harden-Runner v2.19.0 appears in job logs
- [ ] Verify the nested reusable call (`claude-code.yml → preflight.yml`) resolves correctly from consumer repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)