### PR TITLE
fix(security): harden go-ci.yml + go-sec.yml — pinned OS + bumped deps

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -143,7 +143,7 @@ jobs:
   # as passing for required status checks (unlike paths: filters which leave
   # checks stuck "Pending").
   preflight:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: read
@@ -152,7 +152,7 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
@@ -192,14 +192,14 @@ jobs:
     name: Module integrity
     needs: preflight
     if: needs.preflight.outputs.has_go == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
@@ -210,7 +210,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
           cache-dependency-path: ${{ inputs.working-directory }}/go.sum
@@ -230,14 +230,14 @@ jobs:
     name: Lint
     needs: preflight
     if: needs.preflight.outputs.has_go == 'true' && inputs.enable-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
@@ -248,7 +248,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
           cache-dependency-path: ${{ inputs.working-directory }}/go.sum
@@ -264,14 +264,14 @@ jobs:
     name: Test
     needs: preflight
     if: needs.preflight.outputs.has_go == 'true' && inputs.enable-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
@@ -282,7 +282,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
           cache-dependency-path: ${{ inputs.working-directory }}/go.sum
@@ -297,7 +297,7 @@ jobs:
 
       - name: Upload coverage
         if: ${{ inputs.upload-coverage && inputs.enable-test }}
-        uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c  # v5.5.1
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ inputs.working-directory }}/coverage.out
@@ -306,7 +306,7 @@ jobs:
     name: Build
     needs: [preflight, test]
     if: needs.preflight.outputs.has_go == 'true' && inputs.enable-build && inputs.build-cmd-path != ''
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
@@ -318,7 +318,7 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
@@ -329,7 +329,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
           cache-dependency-path: ${{ inputs.working-directory }}/go.sum

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -121,7 +121,7 @@ jobs:
   # Always runs on push-to-main, schedule, and workflow_dispatch — weekly
   # baseline scans should always execute regardless of file changes.
   preflight:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: read
@@ -130,7 +130,7 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
@@ -170,7 +170,7 @@ jobs:
     name: Gosec
     needs: preflight
     if: needs.preflight.outputs.has_go == 'true' && inputs.enable-gosec
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -185,7 +185,7 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
@@ -196,8 +196,11 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
+          # Intentionally "stable" (not go-version-file): security scanners
+          # should run against the latest Go toolchain for up-to-date vuln DB
+          # and tool compatibility. go-ci.yml pins to go.mod for build fidelity.
           go-version: "stable"
           cache: false
 
@@ -219,7 +222,7 @@ jobs:
     name: Govulncheck
     needs: preflight
     if: needs.preflight.outputs.has_go == 'true' && inputs.enable-govulncheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -229,7 +232,7 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
@@ -240,8 +243,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
+          # Intentionally "stable" — see gosec job above for rationale.
           go-version: "stable"
           cache: false
 


### PR DESCRIPTION
## Summary
Batched hardening for both Go reusable workflows so consumers bump once:

### go-ci.yml
- **Pin runner OS** — `ubuntu-latest` → `ubuntu-24.04` (5 jobs)
- **Bump Harden-Runner** — v2.18.0 → v2.19.0 (5 instances)
- **Bump actions/setup-go** — v6.3.0 → v6.4.0 (4 instances)
- **Bump codecov/codecov-action** — v5.5.1 → v6.0.0 (Codecov was a prior supply-chain incident target — staying current matters)

### go-sec.yml
- **Pin runner OS** — `ubuntu-latest` → `ubuntu-24.04` (3 jobs)
- **Bump Harden-Runner** — v2.18.0 → v2.19.0 (3 instances)
- **Bump actions/setup-go** — v6.3.0 → v6.4.0 (2 instances)
- **Documented `go-version: "stable"` as intentional** — security scanners need the latest Go toolchain for up-to-date vuln DB; go-ci.yml pins to go.mod for build fidelity

## Test plan
- [ ] Self-test: `test-go-ci.yml` passes against `_test-fixtures/go-minimal`
- [ ] Self-test: `test-go-sec.yml` passes against `_test-fixtures/go-minimal`
- [ ] Consumer repo Go CI still passes after bumping the reusable SHA
- [ ] Confirm Harden-Runner v2.19.0 in job logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)