### PR TITLE
rename: ts-ci.yml → ts-verify.yml

### DIFF
--- a/.github/workflows/test-ts-verify.yml
+++ b/.github/workflows/test-ts-verify.yml
@@ -1,36 +1,36 @@
-name: "Test: ts-ci.yml"
+name: "Test: ts-verify.yml"
 
 on:
   pull_request:
     branches: [main]
     paths:
-      - ".github/workflows/ts-ci.yml"
-      - ".github/workflows/test-ts-ci.yml"
+      - ".github/workflows/ts-verify.yml"
+      - ".github/workflows/test-ts-verify.yml"
       - "_test-fixtures/ts-minimal/**"
   push:
     branches: [main]
     paths:
-      - ".github/workflows/ts-ci.yml"
-      - ".github/workflows/test-ts-ci.yml"
+      - ".github/workflows/ts-verify.yml"
+      - ".github/workflows/test-ts-verify.yml"
       - "_test-fixtures/ts-minimal/**"
 
 permissions:
   contents: read
 
 jobs:
-  call-ts-ci-defaults:
-    name: Call ts-ci (defaults)
+  call-ts-verify-defaults:
+    name: Call ts-verify (defaults)
     timeout-minutes: 20
-    uses: ./.github/workflows/ts-ci.yml
+    uses: ./.github/workflows/ts-verify.yml
     permissions:
       contents: read
     with:
       working-directory: _test-fixtures/ts-minimal
 
-  call-ts-ci-test-only:
-    name: Call ts-ci (test only, no lint/typecheck)
+  call-ts-verify-test-only:
+    name: Call ts-verify (test only, no lint/typecheck)
     timeout-minutes: 20
-    uses: ./.github/workflows/ts-ci.yml
+    uses: ./.github/workflows/ts-verify.yml
     permissions:
       contents: read
     with:

--- a/.github/workflows/ts-verify.yml
+++ b/.github/workflows/ts-verify.yml
@@ -1,4 +1,4 @@
-name: TypeScript CI (Callable)
+name: TypeScript Verify (Callable)
 # Reusable workflow for TypeScript/Node.js repositories in the praetorian-inc org.
 # Provides consistent install + typecheck + lint + test + Harden-Runner across
 # all Claude plugin repos and other TypeScript projects.
@@ -13,7 +13,7 @@ name: TypeScript CI (Callable)
 #     contents: read
 #   jobs:
 #     ci:
-#       uses: praetorian-inc/public-workflows/.github/workflows/ts-ci.yml@<SHA>  # vX.Y.Z
+#       uses: praetorian-inc/public-workflows/.github/workflows/ts-verify.yml@<SHA>  # vX.Y.Z
 #       permissions:
 #         contents: read
 #
@@ -21,7 +21,7 @@ name: TypeScript CI (Callable)
 #
 #   jobs:
 #     ci:
-#       uses: praetorian-inc/public-workflows/.github/workflows/ts-ci.yml@<SHA>  # vX.Y.Z
+#       uses: praetorian-inc/public-workflows/.github/workflows/ts-verify.yml@<SHA>  # vX.Y.Z
 #       permissions:
 #         contents: read
 #       with:


### PR DESCRIPTION
## Summary
Renames `ts-ci.yml` → `ts-verify.yml` (and self-test `test-ts-ci.yml` → `test-ts-verify.yml`).

**Why:** "CI" is jargon that tells you nothing about what the workflow does. "Verify" communicates the intent: **install → typecheck → lint → test** — verify this code is correct before merge.

**Breaking change for callers.** 7 consumer repos need to update their `uses:` path when they bump to this SHA:
- `praetorian-core-plugin`
- `praetorian-it-plugin`
- `praetorian-marketing-plugin`
- `praetorian-finance-plugin`
- `praetorian-sales-plugin`
- `offsec/reporting`
- `offsec/iot`

Old callers pinned to older SHAs are unaffected — `ts-ci.yml` still exists at their pinned commit.

## Test plan
- [ ] Self-test `test-ts-verify.yml` passes against `_test-fixtures/ts-minimal`
- [ ] After merge, sweep 7 consumer repos to update `ts-ci.yml` → `ts-verify.yml` in their caller workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)