### PR TITLE
fix(security): harden external-contrib-notify.yml — pinned OS, bumped HR, per-job permissions

### DIFF
--- a/.github/workflows/external-contrib-notify.yml
+++ b/.github/workflows/external-contrib-notify.yml
@@ -143,18 +143,20 @@ on:
         required: false
 
 permissions:
-  issues: write
-  pull-requests: write
   contents: read
 
 jobs:
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Harden runner
         if: ${{ inputs.enable-harden-runner }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}


### PR DESCRIPTION
## Summary
- **Pin runner OS** — `ubuntu-latest` → `ubuntu-24.04`
- **Bump Harden-Runner** — v2.18.0 → v2.19.0
- **Per-job permissions** — moved `issues: write` + `pull-requests: write` from workflow-level to the `notify` job, leaving workflow-level at `contents: read`. Consistent with the per-job-elevation pattern used across all other reusables.

## Test plan
- [ ] Open an external contribution (fork PR or issue from a non-org member) in a consumer repo — verify Linear issue, Slack notification, and auto-reply still work
- [ ] Confirm Harden-Runner v2.19.0 in job logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)