### PR TITLE
fix(ci): add concurrency cancel-in-progress to self-test workflows

### DIFF
--- a/.github/workflows/test-go-ci.yml
+++ b/.github/workflows/test-go-ci.yml
@@ -12,6 +12,10 @@ on:
       - '_test-fixtures/go-minimal/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test-go-sec.yml
+++ b/.github/workflows/test-go-sec.yml
@@ -18,6 +18,10 @@ on:
       - '_test-fixtures/go-minimal/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test-ts-ci.yml
+++ b/.github/workflows/test-ts-ci.yml
@@ -14,6 +14,10 @@ on:
       - ".github/workflows/test-ts-ci.yml"
       - "_test-fixtures/ts-minimal/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
Added `concurrency: { group: workflow-ref, cancel-in-progress: true }` to all 3 self-test workflows:
- `test-go-ci.yml`
- `test-go-sec.yml`
- `test-ts-ci.yml`

Without this, rapid pushes to a PR branch create parallel runs. Now only the latest push runs.

## Test plan
- [ ] Push two commits in quick succession to a PR that touches `go-ci.yml` — confirm the first run is cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)