### PR TITLE
fix(titus-scan): add pull-requests: read to preflight permissions

### DIFF
--- a/.github/workflows/titus-scan.yml
+++ b/.github/workflows/titus-scan.yml
@@ -100,6 +100,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       should_scan: ${{ steps.check.outputs.should_scan }}
     steps:


### PR DESCRIPTION
## Summary
The preflight job in `titus-scan.yml` calls `gh api repos/.../pulls/.../files` to check PR file changes. This endpoint requires `pull-requests: read`.

When the caller grants explicit per-job permissions (`security-events: write`, `actions: read`), GitHub replaces the entire token scope — `pull-requests` drops to `none`, causing a 403 on the preflight API call.

Adding `pull-requests: read` to the preflight job fixes it.

**Found via:** cato PR #74 failing with `Resource not accessible by integration (HTTP 403)`.

## Test plan
- [ ] Re-run failed checks on cato #74 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)