### PR TITLE
fix(security): env-pass template fields in go-ci and go-sec preflights

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -162,18 +162,21 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eu
 
           # Non-PR events (push to main, schedule, workflow_dispatch) always run.
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "has_go=true" >> "$GITHUB_OUTPUT"
-            echo "✓ Non-PR event (${{ github.event_name }}) — Go CI will run."
+            echo "✓ Non-PR event ($EVENT_NAME) — Go CI will run."
             exit 0
           fi
 
           FILES=$(gh api \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            "repos/$REPO/pulls/$PR_NUMBER/files" \
             --paginate --jq '.[].filename')
 
           echo "Changed files in PR ($(echo "$FILES" | wc -l | tr -d ' ') total):"

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -140,18 +140,21 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eu
 
           # Non-PR events (push to main, schedule, workflow_dispatch) always run.
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "has_go=true" >> "$GITHUB_OUTPUT"
-            echo "✓ Non-PR event (${{ github.event_name }}) — security scan will run."
+            echo "✓ Non-PR event ($EVENT_NAME) — security scan will run."
             exit 0
           fi
 
           FILES=$(gh api \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            "repos/$REPO/pulls/$PR_NUMBER/files" \
             --paginate --jq '.[].filename')
 
           echo "Changed files in PR ($(echo "$FILES" | wc -l | tr -d ' ') total):"


### PR DESCRIPTION
## Summary
Moves `${{ github.event_name }}`, `${{ github.repository }}`, and `${{ github.event.pull_request.number }}` from template interpolation to `env:` blocks in both go-ci.yml and go-sec.yml preflights.

Completes the anti-pattern A21 cleanup — every other reusable workflow (preflight.yml, titus-scan.yml, version-bump.yml) already uses env-passing. These two were the last holdouts.

Low exploitability (integer + fixed strings) but eliminates the inconsistency.

## Test plan
- [ ] Self-tests pass (test-go-ci.yml, test-go-sec.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)