### PR TITLE
Remove invalid timeout-minutes from caller template

### DIFF
--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -18,7 +18,6 @@ name: "CLAUDE.md Drift Detection (Callable)"
 #   jobs:
 #     drift-check:
 #       uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@<SHA>
-#       timeout-minutes: 15
 #       permissions:
 #         contents: read
 #         pull-requests: write


### PR DESCRIPTION
GitHub rejects reusable-workflow caller jobs that include timeout-minutes — only name, uses, with, secrets, permissions, needs, if, concurrency, and strategy are valid keys on a job that uses 'uses:'. Downstream repos copying this template hit a workflow-file parse failure (synthetic failed run with jobs: []).

Per-job timeouts are already enforced upstream (pre-filter: 5m,
drift-check: 10m), so no caller-side cap is needed.