### PR TITLE
fix(ci): add pull-requests: read to go-ci/go-sec preflight permissions

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -147,6 +147,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       has_go: ${{ steps.check.outputs.has_go }}
     steps:

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -125,6 +125,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       has_go: ${{ steps.check.outputs.has_go }}
     steps:


### PR DESCRIPTION
  ## Summary
  - Adds `pull-requests: read` permission to the preflight jobs in `go-ci.yml` and `go-sec.yml`
  - Fixes 403 "Resource not accessible by integration" errors when preflight jobs query PR changed files
  - Matches the same fix already applied to `titus-scan` in #58