### PR TITLE
feat(version): bump and check both plugin.json and package.json

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -102,7 +102,21 @@ jobs:
           esac
 
           echo "New version: $NEW_VERSION (was $CURRENT, bump: ${{ steps.bump.outputs.level }})"
+
+          # Bump plugin.json (always present in plugin repos).
           jq --arg v "$NEW_VERSION" '.version = $v' .claude-plugin/plugin.json > tmp.json && mv tmp.json .claude-plugin/plugin.json
+
+          # Bump package.json if it exists with a "version" field. Plugin repos
+          # that ship TypeScript wrappers (sales, marketing, finance, IT, etc.)
+          # carry both files and policy is to keep them in sync. Anthropic's
+          # own claude-plugins-official agent bumps both — match that pattern.
+          # Conditional so non-plugin repos (orator, guard-core, capabilities
+          # without TS) are unaffected.
+          if [ -f package.json ] && jq -e 'has("version")' package.json >/dev/null 2>&1; then
+            jq --arg v "$NEW_VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+            echo "Also bumped package.json to $NEW_VERSION"
+          fi
+
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push to PR branch
@@ -113,6 +127,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .claude-plugin/plugin.json
+          # Stage package.json too if it was bumped above (kept in sync with
+          # plugin.json per Anthropic's claude-plugins-official pattern).
+          if [ -f package.json ]; then
+            git add package.json
+          fi
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "chore: bump version to $NEW_VERSION"
           git push origin "HEAD:$HEAD_REF"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -56,3 +56,21 @@ jobs:
           fi
 
           echo "Version bumped: $BASE_VERSION -> $PR_VERSION"
+
+          # If the repo also carries a package.json (plugin repos with TS
+          # wrappers — sales, marketing, finance, IT, engineering, etc.),
+          # enforce parity per Anthropic's claude-plugins-official pattern.
+          # Repos without package.json (orator, guard-core, capability tools
+          # without TS) are unaffected.
+          if [ -f package.json ] && jq -e 'has("version")' package.json >/dev/null 2>&1; then
+            PKG_VERSION=$(jq -r '.version' package.json)
+            if [ "$PKG_VERSION" != "$PR_VERSION" ]; then
+              echo "::error::package.json version ($PKG_VERSION) does not match plugin.json version ($PR_VERSION)."
+              echo "::error::Both files must be in sync. The version-bump auto-tool handles this on PR open;"
+              echo "::error::if the policy was added after the PR opened, add the 'bump' label to retry, or"
+              echo "::error::sync manually by running:"
+              echo "::error::  jq --arg v \"$PR_VERSION\" '.version = \$v' package.json > tmp.json && mv tmp.json package.json"
+              exit 1
+            fi
+            echo "package.json version matches plugin.json: $PKG_VERSION"
+          fi


### PR DESCRIPTION
## Summary

Bring `version-bump.yml` and `version-check.yml` in line with [Anthropic's `claude-plugins-official` convention](https://github.com/anthropics/claude-plugins-official): when a plugin repo carries both `.claude-plugin/plugin.json` AND `package.json`, keep their `version` fields in sync.

## Why

Anthropic's [Plugins Reference](https://code.claude.com/docs/en/plugins-reference) explicitly states:

> If both `plugin.json` and `package.json` have versions set, `plugin.json` takes priority, but you should keep them in sync to avoid confusion.

Their official plugin repo includes a `version-bump` agent that bumps **both files** in a single step.

Praetorian's plugin repos (sales, marketing, finance, IT, engineering, capabilities) all carry both files. Until this change, our auto-bump tool only modified `plugin.json`, leaving `package.json` permanently drifted at whatever version it was last manually bumped to. `version-check.yml` did not catch the drift because it only validated `plugin.json`.

This was surfaced by CodeRabbit on `praetorian-sales` PR #170. Currently, `praetorian-sales` `main` has `plugin.json: 3.20.2` but `package.json: 3.19.0` — drift the policy in [CLAUDE.md](https://github.com/praetorian-inc/praetorian-sales/blob/main/CLAUDE.md) explicitly forbids:

> Both `.claude-plugin/plugin.json` and `package.json` carry versions — keep them in sync. `version-check.yml` GitHub workflow fails PRs that don't bump the version.

The tooling just hadn't caught up to the policy.

## Changes

### `version-bump.yml`

After bumping `plugin.json`, also bump `package.json` if it exists with a `"version"` field. Stage both for the auto-commit.

```bash
# Bump plugin.json (always present in plugin repos).
jq --arg v "$NEW_VERSION" '.version = $v' .claude-plugin/plugin.json > tmp.json && mv tmp.json .claude-plugin/plugin.json

# Bump package.json if it exists with a "version" field.
if [ -f package.json ] && jq -e 'has("version")' package.json >/dev/null 2>&1; then
  jq --arg v "$NEW_VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
fi
```

Plus the `git add package.json` in the commit step.

### `version-check.yml`

After validating `plugin.json` was bumped, validate that `package.json` (if present with a version field) matches.

```bash
if [ -f package.json ] && jq -e 'has("version")' package.json >/dev/null 2>&1; then
  PKG_VERSION=$(jq -r '.version' package.json)
  if [ "$PKG_VERSION" != "$PR_VERSION" ]; then
    echo "::error::package.json version ($PKG_VERSION) does not match plugin.json version ($PR_VERSION)."
    exit 1
  fi
fi
```

## Backwards compatibility

Both checks are guarded by `[ -f package.json ] && jq -e 'has("version")' ...`. Repos without `package.json` (or without a version field) see no behavior change:

| Repo | Has `plugin.json` | Has `package.json` with version | Behavior |
|---|---|---|---|
| praetorian-sales | yes | yes | Now bumps both ✓ |
| praetorian-marketing | yes | yes | Now bumps both ✓ |
| praetorian-finance | yes | yes | Now bumps both ✓ |
| praetorian-it | yes | yes | Now bumps both ✓ |
| praetorian-engineering | yes | yes | Now bumps both ✓ |
| praetorian-capabilities | yes | (varies) | Conditional |
| orator | no | (Go binary repo) | Unchanged |
| guard-core | no | yes (root, but not a plugin) | Unchanged |
| capability scanners | no | (Go binaries) | Unchanged |

## Test plan

- [ ] Open a test PR in praetorian-sales (or any plugin repo) after this lands and is SHA-pinned. Verify auto-bump commits both `plugin.json` and `package.json` together with matching versions.
- [ ] Open a test PR with intentionally-mismatched versions (e.g., bump only `plugin.json`). Verify `version-check.yml` fails with the new error message.
- [ ] Open a test PR in a repo that has only `plugin.json` (no `package.json`). Verify behavior is unchanged.
- [ ] Open a test PR in a repo with neither file (e.g., orator). Verify the workflow is a no-op as before.

## Rollout (after merge + tag)

Once tagged (suggest `v2.2.0` for the additive feature), update SHA pins in plugin repo callers:

- `praetorian-sales/.github/workflows/version-bump.yml` and `version-check.yml`
- `praetorian-marketing/.github/workflows/version-bump.yml` and `version-check.yml`
- `praetorian-finance/...`
- `praetorian-it/...`
- `praetorian-engineering/...` (`guard-platform/praetorian-engineering-plugin`)
- `praetorian-capabilities/...`
- `praetorian-pmo/...`, `praetorian-pm/...`
- `praetorian-core/...`

Existing `main`-branch drift in those repos (where `plugin.json` and `package.json` are out of sync) will need a one-time manual sync — either a small chore PR per repo, or rolled into the next regular PR's auto-bump after the SHA pin is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)