### PR TITLE
feat: add markdown-quality reusable workflow and pre-commit templates

### DIFF
--- a/.github/workflows/markdown-quality.yml
+++ b/.github/workflows/markdown-quality.yml
@@ -1,0 +1,220 @@
+name: Markdown Quality (Callable)
+# Reusable workflow for markdown-heavy repositories in the praetorian-inc org.
+# Runs markdownlint (structural quality) + prettier (table/format alignment)
+# in check mode. No auto-fix — fails with instructions to run locally.
+#
+# Designed for repos with no package.json (pure markdown repos like guard-skills,
+# documentation, plugin skill libraries). Uses npx to download tools on demand.
+#
+# Caller example (drop this in .github/workflows/markdown-quality.yml):
+#
+#   name: Markdown Quality
+#   on:
+#     push: { branches: [main] }
+#     pull_request: { branches: [main] }
+#   permissions:
+#     contents: read
+#   jobs:
+#     quality:
+#       uses: praetorian-inc/public-workflows/.github/workflows/markdown-quality.yml@<SHA>
+#       permissions:
+#         contents: read
+#
+# For repos with a custom markdownlint config, place .markdownlint-cli2.jsonc
+# or .markdownlint.jsonc in the repo root. The workflow uses it automatically.
+# If no config exists, a sensible default is generated (see Generate step).
+#
+# For local auto-fix (pre-commit hooks), see templates/markdown/ in this repo.
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: "Working directory for the markdown project."
+        required: false
+        type: string
+        default: "."
+
+      glob:
+        description: "Glob pattern for markdown files to check."
+        required: false
+        type: string
+        default: "**/*.md"
+
+      node-version:
+        description: "Node.js version to use for npx."
+        required: false
+        type: string
+        default: "22"
+
+      enable-markdownlint:
+        description: "Run markdownlint-cli2 for structural markdown quality."
+        required: false
+        type: boolean
+        default: true
+
+      markdownlint-version:
+        description: "Pinned markdownlint-cli2 version. Never use 'latest'."
+        required: false
+        type: string
+        default: "0.22.1"
+
+      enable-prettier:
+        description: "Run prettier --check for table column alignment and formatting."
+        required: false
+        type: boolean
+        default: true
+
+      prettier-version:
+        description: "Pinned prettier version. Never use 'latest'."
+        required: false
+        type: string
+        default: "3.8.3"
+
+      enable-harden-runner:
+        description: "Enable StepSecurity Harden-Runner as the first step."
+        required: false
+        type: boolean
+        default: true
+
+      harden-runner-policy:
+        description: "Harden-Runner egress policy: 'audit' or 'block'."
+        required: false
+        type: string
+        default: "audit"
+
+      harden-runner-allowed-endpoints:
+        description: "Newline-separated allowed endpoints for block mode."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      has_md: ${{ steps.check.outputs.has_md }}
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+          disable-sudo-and-containers: true
+
+      - name: Check for markdown changes
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+
+          # Non-PR events (push to main, schedule, dispatch) always run.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "has_md=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Non-PR event (${{ github.event_name }}) — markdown quality will run."
+            exit 0
+          fi
+
+          FILES=$(gh api \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename')
+
+          if echo "$FILES" | grep -E '\.md$' | grep -q .; then
+            echo "has_md=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Markdown changes detected — quality checks will run."
+          else
+            echo "has_md=false" >> "$GITHUB_OUTPUT"
+            echo "⊘ No markdown changes — quality checks will be skipped."
+          fi
+
+  quality:
+    name: Lint & format check
+    needs: preflight
+    if: needs.preflight.outputs.has_md == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+          disable-sudo-and-containers: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Generate default markdownlint config
+        if: ${{ inputs.enable-markdownlint }}
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          # Use repo config if it exists; otherwise generate a sensible default.
+          # The default disables rules that conflict with common markdown patterns:
+          #   MD013: line length — tables, URLs, and code lines regularly exceed 80 chars
+          #   MD033: inline HTML — <details>, <summary>, HTML tables are used in skills/docs
+          #   MD041: first-line heading — YAML frontmatter (---) is the first line in skills
+          #   MD024: duplicate headings — allowed in sibling sections (e.g., "Step 1" under different parents)
+          for f in .markdownlint-cli2.jsonc .markdownlint-cli2.yaml .markdownlint.jsonc .markdownlint.json .markdownlint.yaml; do
+            if [ -f "$f" ]; then
+              echo "Using repo-provided markdownlint config: $f"
+              exit 0
+            fi
+          done
+
+          cat > .markdownlint-cli2.jsonc << 'MLCFG'
+          {
+            "config": {
+              "MD013": false,
+              "MD033": false,
+              "MD041": false,
+              "MD024": { "siblings_only": true }
+            }
+          }
+          MLCFG
+          echo "Generated default markdownlint config (no repo config found)"
+
+      - name: Markdownlint
+        if: ${{ inputs.enable-markdownlint }}
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          echo "Running markdownlint-cli2@${{ inputs.markdownlint-version }}..."
+          npx markdownlint-cli2@${{ inputs.markdownlint-version }} "${{ inputs.glob }}" || {
+            echo ""
+            echo "::error::Markdown lint errors found. Fix locally with:"
+            echo "  npx markdownlint-cli2 --fix \"${{ inputs.glob }}\""
+            echo ""
+            echo "Or install pre-commit hooks (see public-workflows/templates/markdown/)."
+            exit 1
+          }
+
+      - name: Prettier format check
+        if: ${{ inputs.enable-prettier && (success() || failure()) }}
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          echo "Running prettier@${{ inputs.prettier-version }} --check..."
+          npx prettier@${{ inputs.prettier-version }} --check --parser markdown "${{ inputs.glob }}" || {
+            echo ""
+            echo "::error::Table/format issues found. Fix locally with:"
+            echo "  npx prettier --write --parser markdown \"${{ inputs.glob }}\""
+            echo ""
+            echo "Or install pre-commit hooks (see public-workflows/templates/markdown/)."
+            exit 1
+          }

--- a/.github/workflows/markdown-quality.yml
+++ b/.github/workflows/markdown-quality.yml
@@ -127,7 +127,7 @@ jobs:
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
             --paginate --jq '.[].filename')
 
-          if echo "$FILES" | grep -E '\.md$' | grep -q .; then
+          if echo "$FILES" | grep -qE '\.(md|markdown)$'; then
             echo "has_md=true" >> "$GITHUB_OUTPUT"
             echo "✓ Markdown changes detected — quality checks will run."
           else
@@ -194,12 +194,15 @@ jobs:
       - name: Markdownlint
         if: ${{ inputs.enable-markdownlint }}
         working-directory: ${{ inputs.working-directory }}
+        env:
+          MDLINT_VERSION: ${{ inputs.markdownlint-version }}
+          MDLINT_GLOB: ${{ inputs.glob }}
         run: |
-          echo "Running markdownlint-cli2@${{ inputs.markdownlint-version }}..."
-          npx markdownlint-cli2@${{ inputs.markdownlint-version }} "${{ inputs.glob }}" || {
+          echo "Running markdownlint-cli2@${MDLINT_VERSION}..."
+          npx "markdownlint-cli2@${MDLINT_VERSION}" "${MDLINT_GLOB}" || {
             echo ""
             echo "::error::Markdown lint errors found. Fix locally with:"
-            echo "  npx markdownlint-cli2 --fix \"${{ inputs.glob }}\""
+            echo "  npx markdownlint-cli2 --fix \"${MDLINT_GLOB}\""
             echo ""
             echo "Or install pre-commit hooks (see public-workflows/templates/markdown/)."
             exit 1
@@ -208,12 +211,15 @@ jobs:
       - name: Prettier format check
         if: ${{ inputs.enable-prettier && (success() || failure()) }}
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PRETTIER_VERSION: ${{ inputs.prettier-version }}
+          PRETTIER_GLOB: ${{ inputs.glob }}
         run: |
-          echo "Running prettier@${{ inputs.prettier-version }} --check..."
-          npx prettier@${{ inputs.prettier-version }} --check --parser markdown "${{ inputs.glob }}" || {
+          echo "Running prettier@${PRETTIER_VERSION} --check..."
+          npx "prettier@${PRETTIER_VERSION}" --check --parser markdown "${PRETTIER_GLOB}" || {
             echo ""
             echo "::error::Table/format issues found. Fix locally with:"
-            echo "  npx prettier --write --parser markdown \"${{ inputs.glob }}\""
+            echo "  npx prettier --write --parser markdown \"${PRETTIER_GLOB}\""
             echo ""
             echo "Or install pre-commit hooks (see public-workflows/templates/markdown/)."
             exit 1

--- a/README.md
+++ b/README.md
@@ -292,6 +292,43 @@ jobs:
 
 **Security posture:** Workflow-level `permissions: contents: read` ceiling. GitHub App token passed via `env:` (not inline `${{ }}`). Harden-Runner enabled by default. Runner pinned to `ubuntu-24.04`.
 
+### `markdown-quality.yml` — Markdown lint + format check
+
+Reusable workflow for markdown-heavy repositories (skills, docs, plugin libraries). Runs markdownlint (structural quality) + prettier (table/format alignment) in check mode. Designed for repos with no `package.json` — uses `npx` to download tools on demand.
+
+**Minimal caller** (drop this in `.github/workflows/markdown-quality.yml` of a consumer repo):
+
+```yaml
+name: Markdown Quality
+on:
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
+permissions:
+  contents: read
+jobs:
+  quality:
+    uses: praetorian-inc/public-workflows/.github/workflows/markdown-quality.yml@<SHA>
+    permissions:
+      contents: read
+```
+
+**All inputs** (all optional with sensible defaults):
+
+| Input | Default | Purpose |
+|---|---|---|
+| `working-directory` | `.` | Working dir for the markdown project |
+| `glob` | `**/*.md` | Glob pattern for markdown files |
+| `node-version` | `22` | Node.js version for npx |
+| `enable-markdownlint` | `true` | Run markdownlint-cli2 |
+| `markdownlint-version` | `0.22.1` | Pinned markdownlint-cli2 version |
+| `enable-prettier` | `true` | Run prettier table/format check |
+| `prettier-version` | `3.8.3` | Pinned prettier version |
+| `enable-harden-runner` | `true` | Install StepSecurity Harden-Runner |
+| `harden-runner-policy` | `audit` | `audit` or `block` |
+| `harden-runner-allowed-endpoints` | `""` | Egress allowlist for block mode |
+
+**Pre-commit hooks (local auto-fix):** See [`templates/markdown/`](templates/markdown/) for canonical `.pre-commit-config.yaml` and `.markdownlint-cli2.jsonc` that run the same checks with `--fix`/`--write` on commit. CI is the enforcement gate; pre-commit hooks are developer convenience.
+
 ### `version-{bump,check,set}.yml` — Claude plugin version management
 
 Three workflows that manage `.claude-plugin/plugin.json` version lifecycle on PRs.

--- a/templates/markdown/.markdownlint-cli2.jsonc
+++ b/templates/markdown/.markdownlint-cli2.jsonc
@@ -1,0 +1,28 @@
+{
+  // Shared markdownlint config for Praetorian markdown-heavy repos.
+  // Source: praetorian-inc/public-workflows/templates/markdown/
+  //
+  // Used by:
+  //   - pre-commit hooks (markdownlint-cli2 --fix)
+  //   - CI workflow (markdown-quality.yml generates this as default if missing)
+  //
+  // Copy to your repo root alongside .pre-commit-config.yaml.
+  "config": {
+    // MD013: Line length — disabled.
+    // Skills have long SQL payloads, table rows, and URLs that regularly exceed 80 chars.
+    // Wrapping these harms readability more than long lines do.
+    "MD013": false,
+
+    // MD033: Inline HTML — disabled.
+    // Skills and docs use <details>, <summary>, and HTML tables for progressive disclosure.
+    "MD033": false,
+
+    // MD041: First line should be a top-level heading — disabled.
+    // Skills start with YAML frontmatter (---), not a heading.
+    "MD041": false,
+
+    // MD024: Duplicate headings — allowed in sibling sections.
+    // Skills reuse headings like "Step 1", "Usage", "Example" under different parent sections.
+    "MD024": { "siblings_only": true }
+  }
+}

--- a/templates/markdown/.pre-commit-config.yaml
+++ b/templates/markdown/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Canonical pre-commit config for Praetorian markdown-heavy repos.
+# Source: praetorian-inc/public-workflows/templates/markdown/
+#
+# Copy this file to your repo root, then:
+#   pip install pre-commit
+#   pre-commit install
+#
+# Hooks run with --fix/--write: commits go in already formatted.
+# CI (markdown-quality.yml) runs the same checks in --check mode as the gate.
+
+repos:
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.22.1
+    hooks:
+      - id: markdownlint-cli2
+        args: ["--fix"]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        types: [markdown]

--- a/templates/markdown/.pre-commit-config.yaml
+++ b/templates/markdown/.pre-commit-config.yaml
@@ -15,8 +15,11 @@ repos:
       - id: markdownlint-cli2
         args: ["--fix"]
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: local
     hooks:
       - id: prettier
+        name: prettier (markdown tables)
+        entry: prettier --write --parser markdown
+        language: node
         types: [markdown]
+        additional_dependencies: ['prettier@3.8.3']

--- a/templates/markdown/README.md
+++ b/templates/markdown/README.md
@@ -1,0 +1,77 @@
+# Markdown Quality Templates
+
+Canonical configs for markdown-heavy repos. Provides two complementary quality layers:
+
+| Layer | Tool | Mode | Purpose |
+| --- | --- | --- | --- |
+| **CI workflow** | `markdown-quality.yml` | `--check` (fail) | Enforcement gate on PRs |
+| **Pre-commit hook** | `.pre-commit-config.yaml` | `--fix` (auto-fix) | Developer convenience on commit |
+
+Both layers run the same tools with the same rules. CI catches AI agent commits that bypass local hooks.
+
+## Setup
+
+### 1. CI workflow (required)
+
+Add `.github/workflows/markdown-quality.yml` to your repo:
+
+```yaml
+name: Markdown Quality
+on:
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
+permissions:
+  contents: read
+jobs:
+  quality:
+    uses: praetorian-inc/public-workflows/.github/workflows/markdown-quality.yml@<SHA>
+    permissions:
+      contents: read
+```
+
+### 2. Pre-commit hooks (recommended)
+
+Copy these files to your repo root:
+
+```bash
+cp templates/markdown/.pre-commit-config.yaml <your-repo>/
+cp templates/markdown/.markdownlint-cli2.jsonc <your-repo>/
+```
+
+Then install:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Commits are auto-formatted from this point forward.
+
+## What each tool checks
+
+**markdownlint-cli2** (structural quality):
+
+- Heading levels, blank lines, list formatting
+- Table structure (MD058)
+- Code block fencing
+- Trailing whitespace
+- *Auto-fixable* with `--fix`
+
+**prettier** (format alignment):
+
+- Table column alignment and padding
+- Consistent separator widths
+- *Auto-fixable* with `--write`
+
+## Customization
+
+The CI workflow generates a default `.markdownlint-cli2.jsonc` if your repo doesn't have one. To customize rules, copy the template config and modify it — the CI workflow detects and uses your repo-local config automatically.
+
+## Disabled rules (and why)
+
+| Rule | Reason |
+| --- | --- |
+| MD013 (line length) | Tables, URLs, SQL payloads, and code blocks regularly exceed 80 chars |
+| MD033 (inline HTML) | `<details>`, `<summary>`, HTML tables used for progressive disclosure |
+| MD041 (first-line heading) | Skills start with YAML frontmatter (`---`), not headings |
+| MD024 (duplicate headings) | Allowed in sibling sections (e.g., repeated "Usage" under different parents) |


### PR DESCRIPTION
## Summary

- New reusable workflow `markdown-quality.yml` — same pattern as `go-ci.yml` and `ts-ci.yml` but for markdown-heavy repos
- New `templates/markdown/` directory with canonical pre-commit configs for local auto-fix
- Two-layer architecture: CI enforcement gate + pre-commit developer convenience

### Layer 1: CI Workflow (`markdown-quality.yml`)

Runs **markdownlint-cli2** (structural quality) + **prettier --check** (table alignment) on PRs. Designed for repos with no `package.json` — uses `npx` to download tools on demand.

- Preflight job skips PRs with no `.md` changes
- Generates default `.markdownlint-cli2.jsonc` if repo has none (uses repo config if present)
- Pinned tool versions: markdownlint-cli2@0.22.1, prettier@3.8.3
- Harden-Runner, SHA-pinned actions (`checkout@v6.0.2`, `setup-node@v6.4.0`, `harden-runner@v2.19.0`), `timeout-minutes` on all jobs

### Layer 2: Pre-commit Templates (`templates/markdown/`)

Canonical `.pre-commit-config.yaml` and `.markdownlint-cli2.jsonc` for repos to copy. Hooks run with `--fix`/`--write` so commits go in already formatted.

### Why two layers?

The primary contributors to markdown repos are **AI agents** (Claude, Codex, Gemini via PR review workflows). AI agents don't run pre-commit hooks — they commit directly. CI catches their formatting issues. The pre-commit hook is convenience for human editors.

### Disabled rules (and why)

| Rule | Reason |
|---|---|
| MD013 (line length) | Tables, URLs, SQL payloads exceed 80 chars |
| MD033 (inline HTML) | `<details>`, `<summary>`, HTML tables |
| MD041 (first-line heading) | YAML frontmatter (`---`) is first line |
| MD024 (duplicate headings) | Allowed in sibling sections |

### Target consumers (5,100+ .md files with no quality tooling today)

| Repo | .md files | Current pre-commit |
|---|---|---|
| guard-skills | 68 | None |
| praetorian-engineering-plugin | 976 | None |
| Guard-Documentation | 194 | None |
| MSP-docs | 50 | None |
| Cerebrum | 3,835 | None |

## Test plan

- [ ] Add `markdown-quality.yml` caller to guard-skills as pilot consumer
- [ ] Verify preflight skips non-markdown PRs
- [ ] Verify markdownlint catches structural issues
- [ ] Verify prettier catches table alignment issues
- [ ] Verify default config generation when no repo config exists
- [ ] Verify repo-provided config is used when present
- [ ] Roll out to remaining 4 markdown-heavy repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)