### PR TITLE
feat: add Claude, Codex, and Gemini PR reviewers for public-workflows

### DIFF
--- a/.github/workflows/review-claude.yml
+++ b/.github/workflows/review-claude.yml
@@ -1,0 +1,20 @@
+name: Claude PR Assistant
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: claude-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  claude-code-action:
+    uses: ./.github/workflows/claude-code.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/review-codex.yml
+++ b/.github/workflows/review-codex.yml
@@ -1,0 +1,22 @@
+name: Codex PR Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: codex-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codex-review:
+    uses: ./.github/workflows/codex-code.yml
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      model: "gpt-5.4"
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/review-gemini.yml
+++ b/.github/workflows/review-gemini.yml
@@ -1,0 +1,20 @@
+name: Gemini PR Assistant
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: gemini-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gemini-review:
+    uses: ./.github/workflows/gemini-code.yml
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds three thin caller workflows (`review-claude.yml`, `review-codex.yml`, `review-gemini.yml`) so PRs to public-workflows get the same AI review coverage as every other Praetorian repo
- Uses local refs (`./.github/workflows/`) since the reusables live in this repo
- Org-level secrets (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) were already added to public-workflows' access list

## Why

public-workflows hosts the reusable AI reviewer workflows that 18+ repos call, but never reviewed its own PRs with them. Changes to the reviewers themselves went out without AI review coverage — the shoemaker's children had no shoes.

## Test plan

- [ ] This PR itself should trigger all three reviewers (opened event)
- [ ] Verify Claude, Codex, and Gemini reviews appear as PR review objects
- [ ] Verify preflight correctly skips docs-only PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)