### PR TITLE
feat(release): add go-release.yml and go-auto-tag.yml reusable workflows

### DIFF
--- a/.github/workflows/go-auto-tag.yml
+++ b/.github/workflows/go-auto-tag.yml
@@ -134,6 +134,8 @@ jobs:
           TAG_PREFIX: ${{ inputs.tag-prefix }}
           SEED_VERSION: ${{ inputs.seed-version }}
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          GH_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
@@ -150,6 +152,11 @@ jobs:
 
           # Strip prefix and any pre-release suffix to get clean major.minor.patch
           VERSION=${LATEST_TAG#"$TAG_PREFIX"}
+          # Validate semver format (require at least major.minor)
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Tag $LATEST_TAG is not valid semver. Expected ${TAG_PREFIX}MAJOR.MINOR.PATCH"
+            exit 1
+          fi
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           # Strip pre-release suffix (e.g. 1-pre-guard-0 -> 1)
@@ -160,7 +167,7 @@ jobs:
           # Determine bump level: check commit message first, then branch name
           COMMIT_MSG=$(git log -1 --format=%s)
           BRANCH=""
-          if PR_JSON=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+          if PR_JSON=$(gh api "repos/${GH_REPO}/commits/${GH_SHA}/pulls" \
             --jq '.[0].head.ref // empty' 2>/dev/null); then
             BRANCH="$PR_JSON"
           fi
@@ -188,11 +195,12 @@ jobs:
 
       - name: Create and push tag
         id: tag
+        env:
+          NEW_TAG: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          NEW_TAG="${{ steps.version.outputs.version }}"
 
           # Safety: don't create a tag that already exists
           if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then

--- a/.github/workflows/go-auto-tag.yml
+++ b/.github/workflows/go-auto-tag.yml
@@ -1,0 +1,207 @@
+name: Go Auto-Tag (Callable)
+
+# Auto-tags Go module repos on merge to main. Reads the latest semver tag,
+# determines bump level from the merged PR's branch name or commit message
+# convention, creates and pushes the new tag.
+#
+# Callers: any Go repo that wants automatic semver tags on every merge.
+# Tags created with GITHUB_TOKEN do NOT trigger other workflows (by design).
+# If the caller also needs a binary release, chain a build job via `needs:`
+# using the `version` output, or use a GitHub App token (secrets.APP_*)
+# to push the tag so it DOES trigger tag-based release workflows.
+#
+# Replaces the ad-hoc version logic previously copy-pasted into caligula
+# and trajan Makefiles. Single source of truth for version calculation.
+#
+# Caller example:
+#   jobs:
+#     auto-tag:
+#       uses: praetorian-inc/public-workflows/.github/workflows/go-auto-tag.yml@<SHA>
+#       permissions:
+#         contents: write
+
+on:
+  workflow_call:
+    inputs:
+      default-bump:
+        description: "Default bump level when no convention is detected (patch, minor, major)."
+        required: false
+        type: string
+        default: "patch"
+
+      major-pattern:
+        description: "Commit message or branch pattern that triggers a major bump."
+        required: false
+        type: string
+        default: "[major-release]"
+
+      minor-pattern:
+        description: "Commit message or branch pattern that triggers a minor bump."
+        required: false
+        type: string
+        default: "[minor-release]"
+
+      tag-prefix:
+        description: "Prefix for version tags (typically 'v')."
+        required: false
+        type: string
+        default: "v"
+
+      seed-version:
+        description: "Initial version when no tags exist yet (without prefix)."
+        required: false
+        type: string
+        default: "0.1.0"
+
+      enable-harden-runner:
+        description: "Whether to install StepSecurity Harden-Runner as the first step."
+        required: false
+        type: boolean
+        default: true
+
+      harden-runner-policy:
+        description: "Harden-Runner egress policy: 'audit' or 'block'."
+        required: false
+        type: string
+        default: "audit"
+
+      harden-runner-allowed-endpoints:
+        description: "Newline-separated allowed egress endpoints when policy=block."
+        required: false
+        type: string
+        default: ""
+
+    outputs:
+      version:
+        description: "The new version tag that was created (e.g. v1.2.3)."
+        value: ${{ jobs.auto-tag.outputs.version }}
+      previous-version:
+        description: "The previous version tag (e.g. v1.2.2), empty if this is the first tag."
+        value: ${{ jobs.auto-tag.outputs.previous_version }}
+      tag-created:
+        description: "Whether a new tag was actually created ('true' or 'false')."
+        value: ${{ jobs.auto-tag.outputs.tag_created }}
+
+permissions:
+  contents: read
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    # Loop guard: skip when this push is the bot's own tag commit, or when
+    # the commit message starts with "chore: bump version" (Dependabot-style).
+    if: |
+      github.actor != 'github-actions[bot]' &&
+      !startsWith(github.event.head_commit.message, 'chore: bump version')
+
+    concurrency:
+      group: go-auto-tag-${{ github.repository }}
+      cancel-in-progress: false
+
+    permissions:
+      contents: write
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      previous_version: ${{ steps.version.outputs.previous_version }}
+      tag_created: ${{ steps.tag.outputs.tag_created }}
+
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+          disable-sudo-and-containers: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --tags --force
+
+      - name: Calculate version
+        id: version
+        env:
+          DEFAULT_BUMP: ${{ inputs.default-bump }}
+          MAJOR_PATTERN: ${{ inputs.major-pattern }}
+          MINOR_PATTERN: ${{ inputs.minor-pattern }}
+          TAG_PREFIX: ${{ inputs.tag-prefix }}
+          SEED_VERSION: ${{ inputs.seed-version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          LATEST_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | head -n1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No existing tags found. Seeding with ${TAG_PREFIX}${SEED_VERSION}"
+            echo "version=${TAG_PREFIX}${SEED_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "previous_version=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "previous_version=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+
+          # Strip prefix and any pre-release suffix to get clean major.minor.patch
+          VERSION=${LATEST_TAG#"$TAG_PREFIX"}
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          # Strip pre-release suffix (e.g. 1-pre-guard-0 -> 1)
+          PATCH=$(echo "$VERSION" | cut -d. -f3 | cut -d- -f1)
+
+          MAJOR=${MAJOR:-0}; MINOR=${MINOR:-0}; PATCH=${PATCH:-0}
+
+          # Determine bump level: check commit message first, then branch name
+          COMMIT_MSG=$(git log -1 --format=%s)
+          BRANCH=""
+          if PR_JSON=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '.[0].head.ref // empty' 2>/dev/null); then
+            BRANCH="$PR_JSON"
+          fi
+
+          BUMP="$DEFAULT_BUMP"
+          if echo "$COMMIT_MSG" | grep -qF "$MAJOR_PATTERN"; then
+            BUMP="major"
+          elif echo "$COMMIT_MSG" | grep -qF "$MINOR_PATTERN"; then
+            BUMP="minor"
+          elif [[ "$BRANCH" == release/* || "$BRANCH" == breaking/* ]]; then
+            BUMP="major"
+          elif [[ "$BRANCH" == feat/* || "$BRANCH" == feature/* ]]; then
+            BUMP="minor"
+          fi
+
+          case "$BUMP" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+
+          NEW_VERSION="${TAG_PREFIX}${MAJOR}.${MINOR}.${PATCH}"
+          echo "Bump: $BUMP | $LATEST_TAG -> $NEW_VERSION (branch: ${BRANCH:-n/a}, msg: $COMMIT_MSG)"
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        id: tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          NEW_TAG="${{ steps.version.outputs.version }}"
+
+          # Safety: don't create a tag that already exists
+          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+            echo "::warning::Tag $NEW_TAG already exists. Skipping."
+            echo "tag_created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+          git push origin "$NEW_TAG"
+          echo "tag_created=true" >> "$GITHUB_OUTPUT"
+          echo "Created and pushed tag: $NEW_TAG"

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,0 +1,421 @@
+name: Go Release (Callable)
+
+# Reusable workflow for Go binary releases in the praetorian-inc org.
+# Covers 90% of capability repos with security hardening baked in:
+# SHA-pinned GoReleaser, SBOM generation (Syft), artifact signing (cosign),
+# and build provenance attestation.
+#
+# Two release modes:
+#   tag-push (default)     — caller triggers on push: tags: ['v*']
+#   auto-tag-from-main     — caller triggers on push: branches: [main];
+#                            this workflow calculates the next semver tag,
+#                            creates it, then runs GoReleaser against it.
+#
+# Access: invocable from any repo in the praetorian-inc org.
+#
+# Caller examples:
+#
+#   # Mode 1: tag-push (most repos)
+#   on:
+#     push:
+#       tags: ['v*']
+#   jobs:
+#     release:
+#       uses: praetorian-inc/public-workflows/.github/workflows/go-release.yml@<SHA>
+#       permissions:
+#         contents: write
+#         id-token: write
+#         attestations: write
+#
+#   # Mode 2: auto-tag-from-main (caligula/trajan pattern)
+#   on:
+#     push:
+#       branches: [main]
+#   jobs:
+#     release:
+#       uses: praetorian-inc/public-workflows/.github/workflows/go-release.yml@<SHA>
+#       permissions:
+#         contents: write
+#         id-token: write
+#         attestations: write
+#       with:
+#         release-mode: auto-tag-from-main
+#
+# Parent: ENG-3079  |  Sibling: go-ci.yml (ENG-3092)
+# Ticket: ENG-3094  |  Blocks: ENG-3095 (per-repo migration sweep)
+
+on:
+  workflow_call:
+    inputs:
+      # ── Release mode ──────────────────────────────────────────
+      release-mode:
+        description: >
+          How the release is triggered.
+          'tag-push': caller triggers on push: tags: ['v*']. The tag already exists.
+          'auto-tag-from-main': caller triggers on push: branches: [main]. This
+          workflow calculates the next semver, creates the tag, then releases.
+        required: false
+        type: string
+        default: "tag-push"
+
+      # ── Auto-tag settings (only used when release-mode = auto-tag-from-main) ──
+      default-bump:
+        description: "Default bump level when no convention is detected (patch, minor, major)."
+        required: false
+        type: string
+        default: "patch"
+
+      major-pattern:
+        description: "Commit message substring that triggers a major bump."
+        required: false
+        type: string
+        default: "[major-release]"
+
+      minor-pattern:
+        description: "Commit message substring that triggers a minor bump."
+        required: false
+        type: string
+        default: "[minor-release]"
+
+      tag-prefix:
+        description: "Prefix for version tags."
+        required: false
+        type: string
+        default: "v"
+
+      seed-version:
+        description: "Initial version when no tags exist (without prefix)."
+        required: false
+        type: string
+        default: "0.1.0"
+
+      # ── GoReleaser ────────────────────────────────────────────
+      goreleaser-version:
+        description: "Pinned GoReleaser version. Never use 'latest'."
+        required: false
+        type: string
+        default: "v2.13.3"
+
+      goreleaser-config-path:
+        description: "Path to GoReleaser config file relative to repo root."
+        required: false
+        type: string
+        default: ".goreleaser.yaml"
+
+      goreleaser-args:
+        description: "Extra args passed to goreleaser release (e.g. '--clean --skip=validate')."
+        required: false
+        type: string
+        default: "release --clean"
+
+      # ── Supply chain security ─────────────────────────────────
+      enable-sbom:
+        description: "Generate Syft SBOMs per archive. Requires sboms: config in .goreleaser.yaml."
+        required: false
+        type: boolean
+        default: true
+
+      enable-sign:
+        description: "Sign checksums with cosign (keyless OIDC via Sigstore)."
+        required: false
+        type: boolean
+        default: true
+
+      enable-provenance:
+        description: "Generate build provenance attestation via actions/attest-build-provenance."
+        required: false
+        type: boolean
+        default: true
+
+      # ── Container publishing ──────────────────────────────────
+      publish-container:
+        description: "Build and push container image to ghcr.io. Requires dockers: config in .goreleaser.yaml."
+        required: false
+        type: boolean
+        default: false
+
+      # ── Runner ────────────────────────────────────────────────
+      runner:
+        description: "Runner label. Override for repos needing larger runners (e.g. 'ubuntu-large-public')."
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
+      # ── Working directory ─────────────────────────────────────
+      working-directory:
+        description: "Working directory for the Go module (useful for multi-module repos)."
+        required: false
+        type: string
+        default: "."
+
+      go-version-file:
+        description: "Path to go.mod (relative to working-directory)."
+        required: false
+        type: string
+        default: "go.mod"
+
+      # ── Harden-Runner ────────────────────────────────────────
+      enable-harden-runner:
+        description: "Whether to install StepSecurity Harden-Runner as the first step."
+        required: false
+        type: boolean
+        default: true
+
+      harden-runner-policy:
+        description: "Harden-Runner egress policy: 'audit' or 'block'."
+        required: false
+        type: string
+        default: "audit"
+
+      harden-runner-allowed-endpoints:
+        description: >
+          Newline-separated allowed egress endpoints when policy=block.
+          Recommended: github.com:443 api.github.com:443
+          objects.githubusercontent.com:443 proxy.golang.org:443
+          sum.golang.org:443 storage.googleapis.com:443
+          fulcio.sigstore.dev:443 rekor.sigstore.dev:443
+          tuf-repo-cdn.sigstore.dev:443 ghcr.io:443
+        required: false
+        type: string
+        default: ""
+
+    outputs:
+      version:
+        description: "The version that was released (e.g. v1.2.3)."
+        value: ${{ jobs.resolve-version.outputs.version }}
+      tag-created:
+        description: "Whether a new tag was created (only true in auto-tag mode)."
+        value: ${{ jobs.resolve-version.outputs.tag_created }}
+
+permissions:
+  contents: read
+
+jobs:
+  # ────────────────────────────────────────────────────────────
+  # Job 1: Resolve the version to release.
+  #
+  # In tag-push mode: extract the tag from GITHUB_REF.
+  # In auto-tag-from-main mode: calculate next semver, create and push tag.
+  # ────────────────────────────────────────────────────────────
+  resolve-version:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    if: |
+      github.actor != 'github-actions[bot]' &&
+      !startsWith(github.event.head_commit.message, 'chore: bump version')
+
+    concurrency:
+      group: go-release-tag-${{ github.repository }}
+      cancel-in-progress: false
+
+    permissions:
+      contents: write
+
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      tag_created: ${{ steps.resolve.outputs.tag_created }}
+      should_release: ${{ steps.resolve.outputs.should_release }}
+
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+          disable-sudo-and-containers: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --tags --force
+
+      - name: Resolve version
+        id: resolve
+        env:
+          RELEASE_MODE: ${{ inputs.release-mode }}
+          DEFAULT_BUMP: ${{ inputs.default-bump }}
+          MAJOR_PATTERN: ${{ inputs.major-pattern }}
+          MINOR_PATTERN: ${{ inputs.minor-pattern }}
+          TAG_PREFIX: ${{ inputs.tag-prefix }}
+          SEED_VERSION: ${{ inputs.seed-version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ "$RELEASE_MODE" = "tag-push" ]; then
+            # Tag already exists — extract from ref
+            VERSION="${GITHUB_REF#refs/tags/}"
+            echo "Tag-push mode: releasing $VERSION"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "tag_created=false" >> "$GITHUB_OUTPUT"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # ── auto-tag-from-main mode ──
+          LATEST_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | head -n1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            NEW_VERSION="${TAG_PREFIX}${SEED_VERSION}"
+            echo "No existing tags. Seeding with $NEW_VERSION"
+          else
+            VERSION=${LATEST_TAG#"$TAG_PREFIX"}
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            PATCH=$(echo "$VERSION" | cut -d. -f3 | cut -d- -f1)
+            MAJOR=${MAJOR:-0}; MINOR=${MINOR:-0}; PATCH=${PATCH:-0}
+
+            # Determine bump: commit message first, then branch name
+            COMMIT_MSG=$(git log -1 --format=%s)
+            BRANCH=""
+            if PR_JSON=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+              --jq '.[0].head.ref // empty' 2>/dev/null); then
+              BRANCH="$PR_JSON"
+            fi
+
+            BUMP="$DEFAULT_BUMP"
+            if echo "$COMMIT_MSG" | grep -qF "$MAJOR_PATTERN"; then
+              BUMP="major"
+            elif echo "$COMMIT_MSG" | grep -qF "$MINOR_PATTERN"; then
+              BUMP="minor"
+            elif [[ "$BRANCH" == release/* || "$BRANCH" == breaking/* ]]; then
+              BUMP="major"
+            elif [[ "$BRANCH" == feat/* || "$BRANCH" == feature/* ]]; then
+              BUMP="minor"
+            fi
+
+            case "$BUMP" in
+              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+              patch) PATCH=$((PATCH + 1)) ;;
+            esac
+
+            NEW_VERSION="${TAG_PREFIX}${MAJOR}.${MINOR}.${PATCH}"
+            echo "Auto-tag: $BUMP bump | $LATEST_TAG -> $NEW_VERSION"
+          fi
+
+          # Safety: skip if tag already exists
+          if git rev-parse "$NEW_VERSION" >/dev/null 2>&1; then
+            echo "::warning::Tag $NEW_VERSION already exists. Skipping release."
+            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+            echo "tag_created=false" >> "$GITHUB_OUTPUT"
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+          git push origin "$NEW_VERSION"
+
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag_created=true" >> "$GITHUB_OUTPUT"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+
+  # ────────────────────────────────────────────────────────────
+  # Job 2: GoReleaser build + release.
+  #
+  # Runs against the resolved version tag. Produces binaries, checksums,
+  # and optionally SBOMs and container images (configured in .goreleaser.yaml).
+  # ────────────────────────────────────────────────────────────
+  goreleaser:
+    needs: resolve-version
+    if: needs.resolve-version.outputs.should_release == 'true'
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
+
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+          disable-sudo-and-containers: false
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.resolve-version.outputs.version }}
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
+          cache: true
+
+      - name: Install Syft (SBOM generator)
+        if: ${{ inputs.enable-sbom }}
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+
+      - name: Install cosign (artifact signing)
+        if: ${{ inputs.enable-sign }}
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb  # v3.8.2
+
+      - name: Login to GHCR
+        if: ${{ inputs.publish-container }}
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2
+        with:
+          version: ${{ inputs.goreleaser-version }}
+          args: ${{ inputs.goreleaser-args }}
+          workdir: ${{ inputs.working-directory }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ needs.resolve-version.outputs.version }}
+
+      - name: Attest build provenance
+        if: ${{ inputs.enable-provenance }}
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-path: |
+            ${{ inputs.working-directory }}/dist/*.tar.gz
+            ${{ inputs.working-directory }}/dist/*.zip
+            ${{ inputs.working-directory }}/dist/checksums.txt
+
+  # ────────────────────────────────────────────────────────────
+  # Job 3: Cleanup on failure.
+  #
+  # If the release pipeline fails after creating a tag (auto-tag mode only),
+  # delete the draft release and tag so the next run can retry cleanly.
+  # ────────────────────────────────────────────────────────────
+  cleanup-on-failure:
+    needs: [resolve-version, goreleaser]
+    if: >
+      failure() &&
+      needs.resolve-version.outputs.tag_created == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Delete release and tag
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Cleaning up failed release $VERSION"
+          gh release delete "$VERSION" --yes 2>/dev/null || true
+          git push --delete origin "$VERSION" 2>/dev/null || true

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -244,11 +244,17 @@ jobs:
           TAG_PREFIX: ${{ inputs.tag-prefix }}
           SEED_VERSION: ${{ inputs.seed-version }}
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          GH_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
           if [ "$RELEASE_MODE" = "tag-push" ]; then
             # Tag already exists — extract from ref
+            if [[ "$GITHUB_REF" != refs/tags/* ]]; then
+              echo "::error::tag-push mode requires a tag ref, got: $GITHUB_REF"
+              exit 1
+            fi
             VERSION="${GITHUB_REF#refs/tags/}"
             echo "Tag-push mode: releasing $VERSION"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -265,6 +271,11 @@ jobs:
             echo "No existing tags. Seeding with $NEW_VERSION"
           else
             VERSION=${LATEST_TAG#"$TAG_PREFIX"}
+            # Validate semver format (require at least major.minor)
+            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+ ]]; then
+              echo "::error::Tag $LATEST_TAG is not valid semver. Expected ${TAG_PREFIX}MAJOR.MINOR.PATCH"
+              exit 1
+            fi
             MAJOR=$(echo "$VERSION" | cut -d. -f1)
             MINOR=$(echo "$VERSION" | cut -d. -f2)
             PATCH=$(echo "$VERSION" | cut -d. -f3 | cut -d- -f1)
@@ -273,7 +284,7 @@ jobs:
             # Determine bump: commit message first, then branch name
             COMMIT_MSG=$(git log -1 --format=%s)
             BRANCH=""
-            if PR_JSON=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            if PR_JSON=$(gh api "repos/${GH_REPO}/commits/${GH_SHA}/pulls" \
               --jq '.[0].head.ref // empty' 2>/dev/null); then
               BRANCH="$PR_JSON"
             fi
@@ -333,6 +344,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
+      attestations: write
 
     steps:
       - name: Harden Runner
@@ -375,7 +387,7 @@ jobs:
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2
         with:
           version: ${{ inputs.goreleaser-version }}
-          args: ${{ inputs.goreleaser-args }}
+          args: ${{ inputs.goreleaser-args }} --config ${{ inputs.goreleaser-config-path }}
           workdir: ${{ inputs.working-directory }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-go-release.yml
+++ b/.github/workflows/test-go-release.yml
@@ -1,0 +1,140 @@
+name: Test go-release.yml (self-test)
+# Self-test harness for go-release.yml and go-auto-tag.yml.
+# Validates YAML syntax, SHA-pinning, version calculation logic, and
+# GoReleaser config. Runs on every PR that touches these workflows.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/go-release.yml'
+      - '.github/workflows/go-auto-tag.yml'
+      - '.github/workflows/test-go-release.yml'
+      - '_test-fixtures/go-release/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ──────────────────────────────────────────────────────────────
+  # Job 1: Validate YAML syntax with yamllint
+  # ──────────────────────────────────────────────────────────────
+  yaml-lint:
+    name: YAML lint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install yamllint
+        run: pip install --quiet yamllint
+
+      - name: Lint workflows
+        run: |
+          yamllint -d '{extends: default, rules: {line-length: disable, truthy: disable, comments-indentation: disable}}' \
+            .github/workflows/go-release.yml \
+            .github/workflows/go-auto-tag.yml
+
+  # ──────────────────────────────────────────────────────────────
+  # Job 2: Verify all actions are SHA-pinned with version comments
+  # ──────────────────────────────────────────────────────────────
+  verify-sha-pins:
+    name: Verify SHA pins
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Check SHA pins
+        run: |
+          set -euo pipefail
+          FAIL=0
+          for file in .github/workflows/go-release.yml .github/workflows/go-auto-tag.yml; do
+            echo "Checking $file..."
+            while IFS= read -r line; do
+              trimmed=$(echo "$line" | sed 's/^[[:space:]]*//')
+              # Skip local references (./.github/workflows/...)
+              echo "$trimmed" | grep -q '\./' && continue
+              if ! echo "$trimmed" | grep -qE '@[a-f0-9]{40}\b'; then
+                echo "  FAIL: not SHA-pinned: $trimmed"
+                FAIL=1
+              fi
+              if ! echo "$trimmed" | grep -qE '#.*v[0-9]'; then
+                echo "  WARN: missing version comment: $trimmed"
+              fi
+            done < <(grep -E '^\s+uses:' "$file")
+          done
+          if [ "$FAIL" -eq 1 ]; then
+            echo "::error::Some actions are not SHA-pinned. Pin to full commit SHA."
+            exit 1
+          fi
+          echo "All actions properly SHA-pinned."
+
+  # ──────────────────────────────────────────────────────────────
+  # Job 3: Unit-test the version calculation algorithm
+  # ──────────────────────────────────────────────────────────────
+  test-version-calc:
+    name: Test version calculation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Run version calculation tests
+        run: bash _test-fixtures/go-release/test-version-calc.sh
+
+  # ──────────────────────────────────────────────────────────────
+  # Job 4: Validate GoReleaser config against test fixture
+  # ──────────────────────────────────────────────────────────────
+  test-goreleaser-check:
+    name: GoReleaser config check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: _test-fixtures/go-release/go.mod
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2
+        with:
+          install-only: true
+          version: v2.13.3
+
+      - name: Validate config
+        working-directory: _test-fixtures/go-release
+        run: goreleaser check

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 _test-fixtures/**/minimal
 _test-fixtures/**/*-*
 !_test-fixtures/ts-minimal/**
+!_test-fixtures/go-release/
+!_test-fixtures/go-release/**
 coverage.out
 
 # Node.js

--- a/_test-fixtures/go-release/.goreleaser.yaml
+++ b/_test-fixtures/go-release/.goreleaser.yaml
@@ -1,0 +1,20 @@
+version: 2
+
+builds:
+  - main: ./cmd/release-test
+    binary: release-test
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+archives:
+  - format: tar.gz
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc

--- a/_test-fixtures/go-release/cmd/release-test/main.go
+++ b/_test-fixtures/go-release/cmd/release-test/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	release "github.com/praetorian-inc/public-workflows/_test-fixtures/go-release"
+)
+
+func main() {
+	fmt.Println(release.Greet(""))
+}

--- a/_test-fixtures/go-release/go.mod
+++ b/_test-fixtures/go-release/go.mod
@@ -1,0 +1,3 @@
+module github.com/praetorian-inc/public-workflows/_test-fixtures/go-release
+
+go 1.25.3

--- a/_test-fixtures/go-release/hello.go
+++ b/_test-fixtures/go-release/hello.go
@@ -1,0 +1,8 @@
+package release
+
+func Greet(name string) string {
+	if name == "" {
+		name = "world"
+	}
+	return "Hello, " + name + "!"
+}

--- a/_test-fixtures/go-release/hello_test.go
+++ b/_test-fixtures/go-release/hello_test.go
@@ -1,0 +1,12 @@
+package release
+
+import "testing"
+
+func TestGreet(t *testing.T) {
+	if got := Greet(""); got != "Hello, world!" {
+		t.Errorf("Greet('') = %q, want %q", got, "Hello, world!")
+	}
+	if got := Greet("Go"); got != "Hello, Go!" {
+		t.Errorf("Greet('Go') = %q, want %q", got, "Hello, Go!")
+	}
+}

--- a/_test-fixtures/go-release/test-version-calc.sh
+++ b/_test-fixtures/go-release/test-version-calc.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unit tests for the version calculation algorithm used by
+# go-release.yml and go-auto-tag.yml. Mirrors the inline bash
+# script exactly — any change there must be reflected here.
+
+PASSED=0
+FAILED=0
+
+TAG_PREFIX="v"
+DEFAULT_BUMP="patch"
+MAJOR_PATTERN="[major-release]"
+MINOR_PATTERN="[minor-release]"
+SEED_VERSION="0.1.0"
+
+calc_version() {
+  local latest_tag="$1"
+  local commit_msg="$2"
+  local branch="${3:-}"
+
+  if [ -z "$latest_tag" ]; then
+    echo "${TAG_PREFIX}${SEED_VERSION}"
+    return
+  fi
+
+  local VERSION=${latest_tag#"$TAG_PREFIX"}
+  local MAJOR MINOR PATCH
+  MAJOR=$(echo "$VERSION" | cut -d. -f1)
+  MINOR=$(echo "$VERSION" | cut -d. -f2)
+  PATCH=$(echo "$VERSION" | cut -d. -f3 | cut -d- -f1)
+  MAJOR=${MAJOR:-0}; MINOR=${MINOR:-0}; PATCH=${PATCH:-0}
+
+  local BUMP="$DEFAULT_BUMP"
+  if echo "$commit_msg" | grep -qF "$MAJOR_PATTERN"; then
+    BUMP="major"
+  elif echo "$commit_msg" | grep -qF "$MINOR_PATTERN"; then
+    BUMP="minor"
+  elif [[ "$branch" == release/* || "$branch" == breaking/* ]]; then
+    BUMP="major"
+  elif [[ "$branch" == feat/* || "$branch" == feature/* ]]; then
+    BUMP="minor"
+  fi
+
+  case "$BUMP" in
+    major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+    minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+    patch) PATCH=$((PATCH + 1)) ;;
+  esac
+
+  echo "${TAG_PREFIX}${MAJOR}.${MINOR}.${PATCH}"
+}
+
+assert_eq() {
+  local test_name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $test_name"
+    PASSED=$((PASSED + 1))
+  else
+    echo "  FAIL: $test_name (expected=$expected, got=$actual)"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+echo "=== Version Calculation Tests ==="
+echo ""
+
+echo "--- Seed version (no existing tags) ---"
+assert_eq "no tags → v0.1.0" "v0.1.0" "$(calc_version "" "fix: something")"
+
+echo "--- Patch bump (default) ---"
+assert_eq "v1.2.3 + fix → v1.2.4" "v1.2.4" "$(calc_version "v1.2.3" "fix: something")"
+assert_eq "v0.0.1 + chore → v0.0.2" "v0.0.2" "$(calc_version "v0.0.1" "chore: cleanup")"
+assert_eq "v10.20.30 + fix → v10.20.31" "v10.20.31" "$(calc_version "v10.20.30" "fix: big numbers")"
+
+echo "--- Minor bump ---"
+assert_eq "v1.2.3 + [minor-release] → v1.3.0" "v1.3.0" "$(calc_version "v1.2.3" "feat: add foo [minor-release]")"
+assert_eq "v1.2.3 + feat/ branch → v1.3.0" "v1.3.0" "$(calc_version "v1.2.3" "fix: something" "feat/add-thing")"
+assert_eq "v1.2.3 + feature/ branch → v1.3.0" "v1.3.0" "$(calc_version "v1.2.3" "fix: something" "feature/add-thing")"
+
+echo "--- Major bump ---"
+assert_eq "v1.2.3 + [major-release] → v2.0.0" "v2.0.0" "$(calc_version "v1.2.3" "breaking: remove API [major-release]")"
+assert_eq "v1.2.3 + release/ branch → v2.0.0" "v2.0.0" "$(calc_version "v1.2.3" "fix: something" "release/v2")"
+assert_eq "v1.2.3 + breaking/ branch → v2.0.0" "v2.0.0" "$(calc_version "v1.2.3" "fix: something" "breaking/remove-api")"
+
+echo "--- Pre-release suffix stripping ---"
+assert_eq "v1.0.1-pre-guard-0 → v1.0.2" "v1.0.2" "$(calc_version "v1.0.1-pre-guard-0" "fix: something")"
+assert_eq "v2.0.0-rc1 → v2.0.1" "v2.0.1" "$(calc_version "v2.0.0-rc1" "fix: something")"
+assert_eq "v1.0.0-alpha → v1.0.1" "v1.0.1" "$(calc_version "v1.0.0-alpha" "fix: something")"
+
+echo "--- Priority: commit message overrides branch name ---"
+assert_eq "[major-release] overrides feat/ → v2.0.0" "v2.0.0" "$(calc_version "v1.2.3" "[major-release]" "feat/something")"
+assert_eq "[minor-release] overrides release/ → v1.3.0" "v1.3.0" "$(calc_version "v1.2.3" "[minor-release]" "release/v2")"
+
+echo "--- Edge cases ---"
+assert_eq "v0.0.0 + patch → v0.0.1" "v0.0.1" "$(calc_version "v0.0.0" "fix: init")"
+assert_eq "v0.0.0 + major → v1.0.0" "v1.0.0" "$(calc_version "v0.0.0" "[major-release]")"
+
+echo ""
+echo "=== Results: $PASSED passed, $FAILED failed ==="
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi

--- a/_test-fixtures/go-release/test-version-calc.sh
+++ b/_test-fixtures/go-release/test-version-calc.sh
@@ -96,6 +96,30 @@ echo "--- Edge cases ---"
 assert_eq "v0.0.0 + patch → v0.0.1" "v0.0.1" "$(calc_version "v0.0.0" "fix: init")"
 assert_eq "v0.0.0 + major → v1.0.0" "v1.0.0" "$(calc_version "v0.0.0" "[major-release]")"
 
+
+echo "--- Custom TAG_PREFIX ---"
+_save_TAG_PREFIX="$TAG_PREFIX"
+TAG_PREFIX="release-"
+assert_eq "release-1.2.3 + fix → release-1.2.4" "release-1.2.4" "$(calc_version "release-1.2.3" "fix: something")"
+TAG_PREFIX="$_save_TAG_PREFIX"
+
+echo "--- Custom SEED_VERSION ---"
+_save_SEED_VERSION="$SEED_VERSION"
+SEED_VERSION="1.0.0"
+assert_eq "no tags + custom seed 1.0.0 → v1.0.0" "v1.0.0" "$(calc_version "" "fix: init")"
+SEED_VERSION="$_save_SEED_VERSION"
+
+echo "--- Custom DEFAULT_BUMP=minor ---"
+_save_DEFAULT_BUMP="$DEFAULT_BUMP"
+DEFAULT_BUMP="minor"
+assert_eq "v1.2.3 + chore + default minor → v1.3.0" "v1.3.0" "$(calc_version "v1.2.3" "chore: something")"
+DEFAULT_BUMP="$_save_DEFAULT_BUMP"
+
+echo "--- Malformed tag missing patch component ---"
+_malformed_result="$(calc_version "v1.2" "fix: something")"
+assert_eq "v1.2 (no patch) + fix → v1.2.1" "v1.2.1" "$_malformed_result"
+# NOTE: PATCH defaults to 0 when missing, so patch bump → v1.2.1
+
 echo ""
 echo "=== Results: $PASSED passed, $FAILED failed ==="
 


### PR DESCRIPTION
## Summary

Centralized Go release infrastructure for the praetorian-inc org (ENG-3094). Replaces ad-hoc release workflows across 15+ capability repos.

- **go-release.yml**: Full binary release via GoReleaser with supply chain security (Syft SBOM, cosign signing, build provenance attestation). Two modes: `tag-push` (existing manual tag workflow) and `auto-tag-from-main` (replaces bespoke caligula/trajan auto-tag logic)
- **go-auto-tag.yml**: Tag-only workflow for pure library repos (janus, janus-framework, aegis-registry) that need semver tags for Dependabot but don't distribute binaries
- **test-go-release.yml**: Self-test harness with YAML lint, SHA-pin verification, 17-case version calculation unit tests, and GoReleaser config validation

### Problem

Guard-core imports 6 Go modules as SHA-pinned pseudo-versions that Dependabot cannot bump (dependabot-core #3017: Dependabot will NOT update pseudo-version to pseudo-version). Root cause: these repos don't create semver tags on merge. Additionally, caligula and trajan independently built ~100-line bespoke auto-tag workflows with copy-pasted version logic.

### Key design decisions

1. **Two workflows**: go-release.yml (full release) vs go-auto-tag.yml (tag-only) to avoid GoReleaser overhead for library repos
2. **Version calculation inside the workflow**: repos don't need a Makefile version target
3. **Supply chain security on by default**: SBOM, signing, provenance are opt-out
4. **SLSA L2, not L3**: True L3 requires slsa-github-generator (conflicts with GoReleaser), deferred per ENG-3088

### Caller templates (for downstream repos)

```yaml
# Auto-tag + release on every merge (caligula/trajan pattern)
jobs:
  release:
    uses: praetorian-inc/public-workflows/.github/workflows/go-release.yml@<SHA>
    permissions: { contents: write, id-token: write, attestations: write }
    with:
      release-mode: auto-tag-from-main

# Tag-only for library repos
jobs:
  auto-tag:
    uses: praetorian-inc/public-workflows/.github/workflows/go-auto-tag.yml@<SHA>
    permissions: { contents: write }

# Manual tag-triggered release (existing pattern)
jobs:
  release:
    uses: praetorian-inc/public-workflows/.github/workflows/go-release.yml@<SHA>
    permissions: { contents: write, id-token: write, attestations: write }
```

### Rollout plan (ENG-3095)

1. **This PR** — deploy reusable workflows
2. **Pilot on augustus** (zero tags, needs .goreleaser.yaml) and **janus** (tag-only)
3. **Migrate guard-core** from pseudo-versions to tagged versions
4. **Standardize caligula/trajan** (replace bespoke workflows with 10-line callers)
5. **Convert remaining repos** (aurelian, nerva, titus, hadrian, vespasian, florian, constantine, cato)

### Investigation: brutus v1.0.1 vs v1.5.1

Guard-core pins brutus at v1.0.1-0.20260212211829-dc3b98b6c46a despite v1.5.1 existing. This is a **real API incompatibility**: the StopOnSuccess field was removed from brutus.Config between v1.0.1 and v1.5.1, and guard-core sets this field in invoke.go:30. One-line fix needed in guard-core (remove the field assignment) before upgrading.

## Tickets

- **ENG-3094** (this PR) — [Foundation] Create centralized go-release.yml
- **ENG-3079** (parent) — Capability repo CI/CD hardening initiative
- **ENG-3092** (sibling) — go-ci.yml (shipped v1.0.4, pattern followed)
- **ENG-3095** (blocked by this) — Per-repo migration sweep
- **ENG-3088** (subsumed) — SLSA provenance
- **ENG-3091** (subsumed) — augustus + domitian release workflow

## Test plan

- [ ] Self-test harness passes (YAML lint, SHA pins, version calc, GoReleaser check)
- [ ] Pilot: augustus adopts auto-tag-from-main caller, first tag v0.1.0 created
- [ ] Pilot: janus adopts auto-tag-only caller, first tag v0.1.0 created
- [ ] Guard-core go get bumps pseudo-versions to tagged versions
- [ ] Dependabot successfully creates version bump PRs for newly-tagged repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)