### PR TITLE
fix: bump golangci-lint default from v2.11.4 to v2.12.2

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -14,7 +14,7 @@ name: Go CI (Callable)
 #       permissions:
 #         contents: read
 #       with:
-#         golangci-lint-version: v2.11.4
+#         golangci-lint-version: v2.12.2
 #       secrets: inherit
 
 on:
@@ -42,7 +42,7 @@ on:
         description: "Pinned golangci-lint binary version. Use a specific version; never 'latest'."
         required: false
         type: string
-        default: "v2.11.4"
+        default: "v2.12.2"
 
       golangci-lint-timeout:
         description: "Timeout for golangci-lint run."


### PR DESCRIPTION
## Summary
- Bump `golangci-lint-version` default in `go-ci.yml` from `v2.11.4` to `v2.12.2`
- Updates header comment example to match
- All consuming repos (10+ capability repos) inherit this default automatically

## Context
This replaces 9 individual per-repo Makefile PRs (now closed) with a single centralized change. The reusable workflow already follows best practices:
- Official `golangci-lint-action` (SHA-pinned binary download, recommended by golangci-lint docs)
- Explicit failure on lint errors (no silent fallback)
- No PATH or `go install` issues

## Test plan
- [ ] Verify `go-ci.yml` YAML is valid
- [ ] Verify consuming repo CI picks up new default on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)