### PR TITLE
feat: add auto-tag workflow for self-versioning

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -6,11 +6,13 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   auto-tag:
     uses: ./.github/workflows/go-auto-tag.yml
     permissions:
       contents: write
+      pull-requests: read
     with:
       default-bump: patch

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,16 @@
+name: Auto Tag
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    uses: ./.github/workflows/go-auto-tag.yml
+    permissions:
+      contents: write
+    with:
+      default-bump: patch


### PR DESCRIPTION
## Summary
- Adds `auto-tag.yml` that calls the existing `go-auto-tag.yml` reusable workflow on every push to main
- Public-workflows gets automatic semver tags (patch bump by default, minor on `feat/*` branches, major on `release/*`)
- Consumers can pin to tagged SHAs instead of raw commit hashes

## Context
ENG-3666 needs a stable SHA to pin 14 new `ci.yml` files to. Today public-workflows tags are created manually. This automates it.

## Test plan
- [ ] Merge this PR → auto-tag creates `v2.4.0` (next patch after v2.3.1)
- [ ] Verify tag appears in `gh api repos/praetorian-inc/public-workflows/tags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)