### PR TITLE
fix(codex-code): pin codex-version 0.135.0 (stop floating-latest server-info flapping)

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -164,9 +164,12 @@ jobs:
 
       - name: Run Codex
         id: run_codex
-        uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031  # v1
+        uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031  # v1.6 (2026-03-16)
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          # Pin CLI+proxy: empty/unset installs @latest, whose --server-info handshake
+          # intermittently breaks vs this action SHA ("Failed to read server info" -> exit 1).
+          codex-version: "0.115.0"
           model: ${{ inputs.model }}
           effort: ${{ inputs.effort }}
           # Hardcoded — callers cannot override. read-only prevents file mutation,

--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -169,7 +169,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           # Pin CLI+proxy: empty/unset installs @latest, whose --server-info handshake
           # intermittently breaks vs this action SHA ("Failed to read server info" -> exit 1).
-          codex-version: "0.115.0"
+          codex-version: "0.135.0"
           model: ${{ inputs.model }}
           effort: ${{ inputs.effort }}
           # Hardcoded — callers cannot override. read-only prevents file mutation,


### PR DESCRIPTION
## Problem
The codex reusable invokes `openai/codex-action@c25d10f3 (v1.6)` **without** a `codex-version`, so the action installs `@openai/codex@latest` + `@openai/codex-responses-api-proxy@latest` at run time. When npm's `latest` drifts (e.g. a `0.136.0-alpha` window on 2026-05-29), the proxy's `--server-info` handshake becomes incompatible with this action SHA: the proxy never writes `<run_id>.json`, the action polls ~100× → `Error reading server info: ENOENT` → `Failed to read server info` → exit 1. It's **intermittent/flapping** (same repo/same SHA flips SUCCESS↔FAIL as npm `latest` moves) and **not** an auth failure. No public-workflows tag fixes it — the action SHA is identical across all tags; the only lever is pinning the CLI.

## Fix
Pass `codex-version: "0.135.0"` (a recent stable) to `openai/codex-action`. The action forwards it to **both** the CLI and proxy installs, so a single pin locks the matching pair and removes the floating-latest exposure. Also corrected the misleading `# v1` SHA comment to `# v1.6`.

## Validation (real CI)
Pointed a throwaway caller at this branch in an entitled repo: the proxy started (`responses-api-proxy listening`), `codex exec --model …` ran, and codex **completed a review and posted it** — confirmed green with both `gpt-5.4` and `gpt-5.5`. (The pre-fix failures were a separate missing-key confound, since fixed.)

## Rollout after merge
Cut a new public-workflows tag and re-point caller `@<SHA>` pins (re-pointing to an existing tag changes nothing — the pin must land first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)