### PR TITLE
ci(codex-code): default model -> gpt-5.5 (centralize so callers needn't pin a model)

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -39,10 +39,10 @@ on:
           - If nothing significant in any section: "No critical issues — LGTM pending human review."
 
       model:
-        description: "Codex model ID. gpt-5.4-mini is the recommended default for cost-efficient reviews. Use gpt-5.4 for deeper analysis or gpt-5.3-codex for complex multi-file reviews."
+        description: "Codex model ID. gpt-5.5 is the standard default for reviews (validated accessible). Override per-caller only for special cases (e.g. gpt-5.4-mini for cost-sensitive repos, gpt-5.3-codex for complex multi-file reviews)."
         required: false
         type: string
-        default: "gpt-5.4-mini"
+        default: "gpt-5.5"
 
       effort:
         description: "Reasoning effort level (minimal, low, medium, high)"
@@ -238,3 +238,4 @@ jobs:
               ].join('\n'),
               event: 'COMMENT',
             });
+


### PR DESCRIPTION
Makes Codex mirror the Claude reviewer's centralization. Sets the reusable's `model` input **default** to `gpt-5.5` (validated accessible) so callers can **omit** `model:` and inherit it — future model bumps become a single reusable edit + re-pin, with **no per-caller sweep** (today's 26-PR sweep is the pain this removes). Per-repo override remains available (e.g. cost-sensitive repos keep `model: "gpt-5.4-mini"`).

Follow-up after merge + tag (v2.4.0): re-point the open codex caller PRs to **remove their explicit `model:` line** + re-pin to v2.4.0, so they inherit the gpt-5.5 default centrally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)