### PR TITLE
fix(auto-tag): place --sort before -- so the latest semver tag is detected

### DIFF
--- a/.github/workflows/go-auto-tag.yml
+++ b/.github/workflows/go-auto-tag.yml
@@ -139,7 +139,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          LATEST_TAG=$(git tag -l -- "${TAG_PREFIX}*" --sort=-v:refname \
+          # NOTE: --sort MUST come before `--`. Anything after `--` is treated as a
+          # pattern (end-of-options), so `git tag -l -- "v*" --sort=-v:refname` silently
+          # ignored the sort, fell back to lexicographic order, and picked v1.0.0 as
+          # "latest" — bumping to v1.0.1 (which exists) and skipping every run. The job
+          # reported success while never tagging. See the loop guard / "already exists".
+          LATEST_TAG=$(git tag -l --sort=-v:refname -- "${TAG_PREFIX}*" \
             | { grep -E "^${TAG_PREFIX}[0-9]+\.[0-9]+(\.[0-9]+(-[a-zA-Z0-9._+-]+)?)?$" || true; } | head -n1)
 
           if [ -z "$LATEST_TAG" ]; then

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -265,7 +265,10 @@ jobs:
           fi
 
           # ── auto-tag-from-main mode ──
-          LATEST_TAG=$(git tag -l -- "${TAG_PREFIX}*" --sort=-v:refname \
+          # --sort MUST precede `--`; after `--` it's parsed as a pattern, so the sort
+          # is dropped and head -n1 returns the lexicographically-first tag (v1.0.0)
+          # instead of the highest semver. Same bug fixed in go-auto-tag.yml.
+          LATEST_TAG=$(git tag -l --sort=-v:refname -- "${TAG_PREFIX}*" \
             | { grep -E "^${TAG_PREFIX}[0-9]+\.[0-9]+(\.[0-9]+(-[a-zA-Z0-9._+-]+)?)?$" || true; } | head -n1)
 
           if [ -z "$LATEST_TAG" ]; then


### PR DESCRIPTION
## Problem

Auto-tag has cut **no tags since it was added** (#76). Every run reports success but creates nothing — e.g. the #80 merge:

```
Bump: patch | v1.0.0 -> v1.0.1 (branch: fix/codex-review-harden-runner-sudo, ...)
##[warning]Tag v1.0.1 already exists. Skipping.
```

It thinks the latest tag is **v1.0.0** (actual latest is v2.3.2).

## Root cause

```bash
git tag -l -- "${TAG_PREFIX}*" --sort=-v:refname
```

`--sort=-v:refname` is placed **after `--`**. `--` is end-of-options, so git parses `--sort=...` as a *pattern*, not a flag. The sort is silently dropped, tags return in lexicographic order, and `head -n1` returns `v1.0.0` (lexically first) instead of the highest semver. Patch-bump → `v1.0.1` → already exists → skip. Silent no-op, green check.

## Fix

Move `--sort=-v:refname` **before** `--` in both `go-auto-tag.yml` and the identical auto-tag-from-main path in `go-release.yml`.

Verified locally against this repo's tag set:
```
buggy:  git tag -l -- "v*" --sort=-v:refname        -> v1.0.0
fixed:  git tag -l --sort=-v:refname -- "v*"          -> v2.3.2
```

## Verification

Merging this PR triggers auto-tag on its own merge commit; with the fix it should compute `v2.3.2 -> v2.3.3` and create the first real auto-tag. (Will confirm post-merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)