### PR TITLE
fix(auto-tag): drop `--` from git tag/push so the tag is actually created

### DIFF
--- a/.github/workflows/go-auto-tag.yml
+++ b/.github/workflows/go-auto-tag.yml
@@ -218,7 +218,11 @@ jobs:
             exit 0
           fi
 
-          git tag -a -- "$NEW_TAG" -m "Release $NEW_TAG"
-          git push origin -- "$NEW_TAG"
+          # No `--` here: `git tag -a` parses -m as an option, and a `--` before the
+          # tag name pushes -m past end-of-options ("fatal: too many arguments").
+          # Push an explicit refs/tags/ refspec so the tag name can never be read as
+          # an option. NEW_TAG is computed as vN.N.N, so it never starts with '-'.
+          git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+          git push origin "refs/tags/$NEW_TAG"
           echo "tag_created=true" >> "$GITHUB_OUTPUT"
           echo "Created and pushed tag: $NEW_TAG"

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -332,8 +332,11 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a -- "$NEW_VERSION" -m "Release $NEW_VERSION"
-          git push origin -- "$NEW_VERSION"
+          # No `--`: `git tag -a` parses -m as an option and a leading `--` pushes it
+          # past end-of-options ("fatal: too many arguments"). Push an explicit
+          # refs/tags/ refspec; NEW_VERSION is vN.N.N so it never starts with '-'.
+          git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+          git push origin "refs/tags/$NEW_VERSION"
 
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "tag_created=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Follow-up to #83

#83 fixed the semver-sort bug, so for the first time the version calc produced a **non-existent** tag (`v2.3.2 -> v2.3.3`) and reached the create/push step — which exposed a **second** latent bug. The auto-tag run on #83's own merge **failed**:

```
Bump: patch | v2.3.2 -> v2.3.3 (branch: fix/auto-tag-semver-sort, ...)   ← calc fixed ✅
git tag -a -- "$NEW_TAG" -m "Release $NEW_TAG"
fatal: too many arguments                                                 ← new failure
```

## Root cause

`git tag -a -- "$TAG" -m "..."` puts `-m` after `--` (end-of-options), so git can't parse it as the message flag → `fatal: too many arguments`. `git push origin -- "$TAG"` is malformed for the same reason. Never hit before because the version bug always short-circuited at "tag already exists → skip."

## Fix (both `go-auto-tag.yml` and `go-release.yml`)

```bash
git tag -a "$TAG" -m "Release $TAG"      # no --
git push origin "refs/tags/$TAG"          # explicit refspec, never read as an option
```

Tag names are computed as `vN.N.N`, so they can never start with `-`.

Verified locally against this repo: `git tag -a -- NAME -m MSG` → exit 128; `git tag -a NAME -m MSG` → exit 0.

## Verification

Merging this triggers auto-tag on its own merge commit; with both fixes in place it should compute `v2.3.2 -> v2.3.3` and **actually create v2.3.3** — the first real auto-tag. Will confirm post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)