### PR TITLE
feat(auto-tag): push tags via praetorian-ci-version-bumper App token

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -16,3 +16,8 @@ jobs:
       pull-requests: read
     with:
       default-bump: patch
+    # Push the tag as the praetorian-ci-version-bumper App so it can bypass the
+    # "Protected Version Tags" ruleset (GITHUB_TOKEN is not a bypass actor).
+    secrets:
+      VERSION_BUMPER_APP_ID: ${{ secrets.VERSION_BUMPER_APP_ID }}
+      VERSION_BUMPER_PRIVATE_KEY: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}

--- a/.github/workflows/go-auto-tag.yml
+++ b/.github/workflows/go-auto-tag.yml
@@ -71,6 +71,14 @@ on:
         type: string
         default: ""
 
+    secrets:
+      VERSION_BUMPER_APP_ID:
+        description: "Optional GitHub App ID (e.g. praetorian-ci-version-bumper). When set, the tag is created/pushed as the App, so it can bypass a Protected-Version-Tags ruleset and trigger tag-based release workflows. Falls back to GITHUB_TOKEN when unset (callers without a protective tag ruleset need nothing)."
+        required: false
+      VERSION_BUMPER_PRIVATE_KEY:
+        description: "Private key for the App above. Required only when VERSION_BUMPER_APP_ID is set."
+        required: false
+
     outputs:
       version:
         description: "The new version tag that was created (e.g. v1.2.3)."
@@ -108,6 +116,11 @@ jobs:
       previous_version: ${{ steps.version.outputs.previous_version }}
       tag_created: ${{ steps.tag.outputs.tag_created }}
 
+    # Mapped from the secret so the optional app-token step can be gated in `if:`
+    # (the secrets context is not available in step conditionals).
+    env:
+      VB_APP_ID: ${{ secrets.VERSION_BUMPER_APP_ID }}
+
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
@@ -117,10 +130,24 @@ jobs:
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
           disable-sudo-and-containers: true
 
+      # Optional: only runs when a caller passes VERSION_BUMPER_APP_ID. Lets the
+      # tag be pushed as the App (a ruleset bypass actor) instead of GITHUB_TOKEN,
+      # which a Protected-Version-Tags ruleset would otherwise reject.
+      - name: Generate app token
+        id: app-token
+        if: ${{ env.VB_APP_ID != '' }}
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        with:
+          app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
+          private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          # The app token (when configured) persists as the push credential, so the
+          # tag push is authorized as the bypass-actor App. Falls back to GITHUB_TOKEN.
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Fetch all tags
         run: git fetch --tags --force


### PR DESCRIPTION
## Why

Final blocker for auto-tag. After #83 (semver sort) and #84 (git args), the run reaches the push but it's **rejected by the "Protected Version Tags" ruleset**:

```
Bump: patch | v2.3.2 -> v2.3.3
! [remote rejected] v2.3.3 -> v2.3.3 (push declined due to repository rule violations)
```

The job pushes as `github-actions[bot]` (GITHUB_TOKEN), which is **not** a bypass actor on that ruleset.

## Change

Adopt the same App-token pattern already used by `version-bump.yml`/`version-set.yml` (which is how `v2.3.2` etc. get pushed past the ruleset):

- `go-auto-tag.yml` gains **optional** `VERSION_BUMPER_APP_ID` / `VERSION_BUMPER_PRIVATE_KEY` secrets. When set, it mints a token via `actions/create-github-app-token` and checks out with it, so the tag push is authorized as the **praetorian-ci-version-bumper** App. Gated on `env.VB_APP_ID != ''`, so existing Go callers (caligula, trajan) that don't pass the secrets keep using GITHUB_TOKEN unchanged.
- `auto-tag.yml` passes the two org secrets through.

## Required admin steps (one-time) before this works

1. **Grant** org secrets `VERSION_BUMPER_APP_ID` + `VERSION_BUMPER_PRIVATE_KEY` to `public-workflows` (currently not in its reachable secrets).
2. **Add** `praetorian-ci-version-bumper` (app id 3393916) as a bypass actor on the *Protected Version Tags* ruleset (id 14166047) — currently only RepositoryRole Admin/Triage bypass.

Until both are done, behavior is unchanged (falls back to GITHUB_TOKEN → still no tag, no regression). After both, merging this triggers auto-tag → `v2.3.2 → v2.3.3` created as the App.

🤖 Generated with [Claude Code](https://claude.com/claude-code)