### PR TITLE
feat(go-release): push auto-tag-from-main tags via version-bumper App token

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -187,6 +187,20 @@ on:
         description: "Whether a new tag was created (only true in auto-tag mode)."
         value: ${{ jobs.resolve-version.outputs.tag_created }}
 
+    secrets:
+      VERSION_BUMPER_APP_ID:
+        description: >
+          Optional GitHub App ID (e.g. praetorian-ci-version-bumper). When set,
+          the auto-tag-from-main tag is created/pushed as the App, so it can
+          bypass a Protected-Version-Tags ruleset that blocks GITHUB_TOKEN. Only
+          used in auto-tag-from-main mode; tag-push mode never creates a tag.
+          Falls back to GITHUB_TOKEN when unset (callers without a tag ruleset
+          need nothing).
+        required: false
+      VERSION_BUMPER_PRIVATE_KEY:
+        description: "Private key for the App above. Required only when VERSION_BUMPER_APP_ID is set."
+        required: false
+
 permissions:
   contents: read
 
@@ -218,6 +232,11 @@ jobs:
       tag_created: ${{ steps.resolve.outputs.tag_created }}
       should_release: ${{ steps.resolve.outputs.should_release }}
 
+    # Mapped from the secret so the optional app-token step can be gated in `if:`
+    # (the secrets context is not available in step conditionals).
+    env:
+      VB_APP_ID: ${{ secrets.VERSION_BUMPER_APP_ID }}
+
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
@@ -227,10 +246,24 @@ jobs:
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
           disable-sudo-and-containers: true
 
+      # Optional: only in auto-tag-from-main mode when a caller passes the App
+      # secrets. Lets the tag be pushed as the App (a creation bypass actor)
+      # instead of GITHUB_TOKEN, which a Protected-Version-Tags ruleset rejects.
+      - name: Generate app token
+        id: app-token
+        if: ${{ inputs.release-mode == 'auto-tag-from-main' && env.VB_APP_ID != '' }}
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        with:
+          app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
+          private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          # App token (when configured) persists as the push credential so the
+          # tag push is authorized as the bypass-actor App. Falls back to GITHUB_TOKEN.
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Fetch all tags
         run: git fetch --tags --force


### PR DESCRIPTION
## Problem

`go-release.yml` in **auto-tag-from-main** mode creates and pushes `v*` tags as `github-actions[bot]`. On **public** repos the org-level **Protected Version Tags** ruleset blocks that push — so **augustus** and **pius** (both public, both `release-mode: auto-tag-from-main`) fail to release the same way public-workflows' own auto-tag did before #85.

## Fix

Mirror the #85 pattern already proven in `go-auto-tag.yml`:
- Accept optional `VERSION_BUMPER_APP_ID` / `VERSION_BUMPER_PRIVATE_KEY` secrets on `workflow_call` (both `required: false`).
- In `resolve-version`, **only when `release-mode == auto-tag-from-main` and the App ID is set**, mint a `create-github-app-token` and use it as the checkout/push credential.
- Falls back to `github.token` when unset → **tag-push mode and private-repo callers are completely unaffected** (private repos have no tag ruleset; `GITHUB_TOKEN` works).

## Security notes

- The `version-bumper` App is a **creation-only** bypass actor (the org tag ruleset was split: `creation` rule with App bypass; `deletion`/`update`/`non_fast_forward` rule **without** App bypass). So even a compromised App key can only *create* tags — never delete or re-point pinned ones.
- Token is repo-scoped + 1h + auto-revoked; action SHA-pinned; `push:main`-only trigger (no fork-PR secret exposure).
- `cleanup-on-failure`'s tag delete is best-effort (`|| true`); on public repos the create-only App can't delete, so a failed release leaves the tag for an admin to remove — non-fatal.

## Egress hardening (intentionally NOT in this PR)

Flipping `harden-runner-policy` to `block` without a verified allowlist would break releases. The recommended allowlist is already documented on the `harden-runner-allowed-endpoints` input; callers should opt into block-mode **after** reviewing audit-mode egress logs (evaluate→block), per our rollout discipline.

## Rollout after merge

Per public auto-tagging repo (augustus, pius): install the App + add the repo secret + pass the secrets through the `release.yml` caller + bump the `go-release.yml` pin. Private/internal repos need nothing.

## Verification

- YAML valid; `actionlint` clean (only pre-existing SC2129 style warnings in the existing version-calc script, untouched here).
- Same mechanism verified end-to-end on `go-auto-tag.yml` today (created v2.3.3 and v2.3.4 via the App under the create-only split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)