### PR TITLE
fix(titus-scan): safe-by-default secret scanning (fail-closed + visibility-aware SARIF upload)

### DIFF
--- a/.github/workflows/titus-scan.yml
+++ b/.github/workflows/titus-scan.yml
@@ -23,9 +23,21 @@ name: Titus Secrets Scan (Callable)
 #       uses: praetorian-inc/public-workflows/.github/workflows/titus-scan.yml@<SHA>
 #       permissions:
 #         contents: read
-#         security-events: write
-#         actions: read
+#         pull-requests: read     # preflight reads changed files to skip docs-only PRs
+#         security-events: write  # titus job declares it — grant even on private repos (else startup_failure)
+#         actions: read           # titus job declares it — grant even on private repos (else startup_failure)
 #       secrets: inherit
+#
+# Posture (safe by default — a caller of ANY visibility can copy the block above verbatim):
+#   - Secret findings FAIL the build by default (fail-on-findings: true).
+#   - SARIF is uploaded to the Security tab ONLY on public repos (GitHub code scanning
+#     is free there). On private/internal repos the upload is auto-skipped — no GitHub
+#     Advanced Security required, and no false-red CI. The scan still runs and still gates.
+#   - A private/internal repo that HAS a GHAS license can opt back in with
+#     `with: { force-upload-private: true }`.
+#   - Grant all four permissions above regardless of visibility: the titus job statically
+#     declares security-events/actions, so omitting them re-triggers a startup_failure
+#     even when the upload is skipped at runtime.
 #
 # Design rationale: Titus lives in its own reusable (separate from go-sec.yml)
 # because (1) it's language-agnostic (not Go-specific), (2) secrets scanning
@@ -60,16 +72,22 @@ on:
         default: false
 
       upload-sarif:
-        description: "Upload SARIF findings to the GitHub Security tab. When true, the caller MUST grant 'security-events: write' and 'actions: read'."
+        description: "Upload SARIF findings to the GitHub Security tab. Auto-skipped on non-public repos unless force-upload-private is set (see below). When uploaded, the caller MUST grant 'security-events: write' and 'actions: read'."
         required: false
         type: boolean
         default: true
 
-      fail-on-findings:
-        description: "Whether to fail the job if Titus finds secrets. Default false (observe-only — findings surface in Security tab)."
+      force-upload-private:
+        description: "Upload SARIF even on private/internal repos. Requires a GitHub Advanced Security license on the repo (the upload step 403s without it). Default false: SARIF upload is auto-skipped on non-public repos so the scanner runs clean without GHAS."
         required: false
         type: boolean
         default: false
+
+      fail-on-findings:
+        description: "Fail the job if Titus finds secrets. Default true (fail-closed). Set false only for a deliberate observe-only rollout."
+        required: false
+        type: boolean
+        default: true
 
       enable-harden-runner:
         description: "Whether to install StepSecurity Harden-Runner."
@@ -103,6 +121,7 @@ jobs:
       pull-requests: read
     outputs:
       should_scan: ${{ steps.check.outputs.should_scan }}
+      visibility: ${{ steps.repo.outputs.visibility }}
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
@@ -111,6 +130,21 @@ jobs:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
           disable-sudo-and-containers: true
+
+      # Resolve repo visibility via the API (reliable on push/PR/schedule/dispatch,
+      # unlike github.event.repository.visibility which is absent on some events).
+      # Drives whether SARIF upload is attempted — never gates the scan itself.
+      - name: Resolve repository visibility
+        id: repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eu
+          VIS=$(gh api "repos/$REPO" --jq '.visibility' 2>/dev/null || echo "")
+          [ -n "$VIS" ] || VIS="unknown"
+          echo "visibility=$VIS" >> "$GITHUB_OUTPUT"
+          echo "Repository visibility: $VIS"
 
       - name: Check for scannable changes
         id: check
@@ -228,8 +262,19 @@ jobs:
             exit $EXIT
           fi
 
+      # Announce (don't silently swallow) when upload is skipped on a non-public repo.
+      - name: Note SARIF upload skipped
+        if: ${{ always() && inputs.upload-sarif && needs.preflight.outputs.visibility != 'public' && !inputs.force-upload-private }}
+        env:
+          VIS: ${{ needs.preflight.outputs.visibility }}
+        run: |
+          echo "::notice::SARIF upload skipped — repository visibility is '$VIS' (not public). The scan ran and fail-on-findings gating is unaffected. To upload to the Security tab on a private/internal repo, enable GitHub Advanced Security and pass with:{ force-upload-private: true }."
+
+      # Upload only when requested AND the repo can accept it: public repos (code
+      # scanning is free) or a private repo that opted in via force-upload-private.
+      # Prevents the GHAS 403 that turns a clean private-repo scan into a false-red.
       - name: Upload Titus SARIF
-        if: ${{ inputs.upload-sarif && always() }}
+        if: ${{ always() && inputs.upload-sarif && (needs.preflight.outputs.visibility == 'public' || inputs.force-upload-private) }}
         uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0  # v4.35.2
         with:
           sarif_file: titus-results.sarif


### PR DESCRIPTION
## Why

A skeptical security review of the org-wide Titus secret-scanner (validated against our `securing-github-workflows` skill + external best practice + a byte-level audit of all 19 callers) found the reusable ships **observe-only and GHAS-coupled by default**. That produced two real problems:

1. **Public repos failed open.** With `fail-on-findings` defaulting to `false`, a secret committed to a *world-readable* repo did **not** break CI — it only surfaced in the Security tab *after* the secret was already public and indexed.
2. **No-GHAS false-red drove disablement.** On private/internal repos, `upload-sarif` (default true) 403s without a GitHub Advanced Security license, turning a *clean* scan into perpetual red CI. That is exactly the alert-fatigue that got one capability repo's scanner `disabled_manually` — the worst outcome (zero coverage).

The fix belongs at the reusable (the single chokepoint), so every current and future caller inherits a safe default instead of each repo re-deriving it.

## Changes

1. **`fail-on-findings` default `false → true`** — fail-closed by default. Verified **no-op for all 19 current callers** (all set it explicitly); only future callers are protected.
2. **Visibility-aware SARIF upload** — `preflight` now resolves repo visibility via `gh api repos/$REPO --jq .visibility` (reliable across push/PR/schedule/dispatch, unlike `github.event.repository.visibility`). The upload step runs only when the repo is **public** *or* the new **`force-upload-private`** input is set. Non-public repos auto-skip the upload (no GHAS 403, no false-red) **and emit a `::notice::`** so the skip is never silent. A GHAS-licensed private repo opts back in with `with: { force-upload-private: true }`.
3. **Fixed the caller-example comment** — added the missing **`pull-requests: read`** (the omission every caller copy-pasted, which caused an org-wide `startup_failure` and silently disabled the scanner). Documented the safe-by-default posture and the "grant all four permissions regardless of visibility" rule.

The actual security controls — *scan runs* + *finding blocks* — are **unchanged**; only the upload (observability) behavior and the failure mode change. The internal callers' explicit `upload-sarif: false` becomes redundant (a follow-up sweep will simplify it).

## Zero-regression proof (all 19 callers)

| Caller group | Today | After this PR |
|---|---|---|
| 11 public (`fail-on-findings:true`, upload default) | scan+gate, upload to Security tab | **identical** (visibility=public → upload still runs) |
| 8 internal (`fail-on-findings:true`, `upload-sarif:false`) | scan+gate, no upload | **identical** (`upload-sarif:false` → upload + notice both suppressed) |

Org-wide code search confirms no titus-scan callers beyond these 19.

## Validation

- `actionlint` clean on all new steps/expressions (the 3 remaining SC2001/SC2086 shellcheck info/style findings are **pre-existing** on the original `sed` / `titus scan $ARGS` lines — out of scope here).
- YAML parses; diff is exactly the four edits, no collateral changes.

## Notes / follow-ups (separate PRs)

- **Pin hygiene**: callers carry a fictional `# v2.2.1` comment over an untagged SHA; a real tag + re-pin sweep is the next stage.
- **harden-runner egress** defaults to `audit` (not `block`) on a `secrets: inherit` job — a later stage will derive the egress allowlist and flip to `block`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
