### PR TITLE
feat(verify-pins): reusable gate rejecting dishonest first-party pin comments

### DIFF
--- a/.github/workflows/verify-pins.yml
+++ b/.github/workflows/verify-pins.yml
@@ -88,7 +88,11 @@ jobs:
           fail=0
           checked=0
 
-          # Every line that pins OWNER_REPO to a 40-char SHA (comment kept for parsing).
+          # Match active `uses:` keys pinning OWNER_REPO to a 40-char SHA (comment kept
+          # for parsing). Anchored to line start (with optional `- ` list prefix and an
+          # optional opening quote) so commented-out lines and run-block strings are
+          # ignored. Assumes first-party reusable pins: a path after the repo name and
+          # canonical lowercase owner/repo (true for all praetorian-inc pins).
           while IFS= read -r line; do
             # Non-greedy anchors: first @SHA and the FIRST '#' comment on the line
             # (avoids grabbing a trailing '# renovate note' as the version).
@@ -122,7 +126,7 @@ jobs:
               fail=1; continue
             fi
             echo "✓ $OWNER_REPO@${sha:0:12} is honestly pinned to $tag"
-          done < <(grep -rhE "^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*${OWNER_REPO}/[^@]*@[0-9a-fA-F]{40}" .github/workflows/ 2>/dev/null || true)
+          done < <(grep -rhE "^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*['\"]?${OWNER_REPO}/[^@]*@[0-9a-fA-F]{40}" .github/workflows/ 2>/dev/null || true)
 
           echo "Checked $checked first-party pin(s) against $OWNER_REPO tags."
           if [ "$fail" -ne 0 ]; then

--- a/.github/workflows/verify-pins.yml
+++ b/.github/workflows/verify-pins.yml
@@ -48,6 +48,12 @@ on:
         type: string
         default: "audit"
 
+      harden-runner-allowed-endpoints:
+        description: "Newline-separated allowed endpoints for block mode (e.g. github.com:443, api.github.com:443). Required if harden-runner-policy is 'block', since this job checks out and calls the GitHub API."
+        required: false
+        type: string
+        default: ""
+
 permissions:
   contents: read
 
@@ -64,6 +70,7 @@ jobs:
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
           disable-sudo-and-containers: true
 
       - name: Checkout
@@ -83,9 +90,11 @@ jobs:
 
           # Every line that pins OWNER_REPO to a 40-char SHA (comment kept for parsing).
           while IFS= read -r line; do
-            sha="$(printf '%s\n' "$line" | sed -nE 's/.*@([0-9a-fA-F]{40}).*/\1/p')"
+            # Non-greedy anchors: first @SHA and the FIRST '#' comment on the line
+            # (avoids grabbing a trailing '# renovate note' as the version).
+            sha="$(printf '%s\n' "$line" | sed -nE 's/[^@]*@([0-9a-fA-F]{40}).*/\1/p')"
             [ -n "$sha" ] || continue
-            tag="$(printf '%s\n' "$line" | sed -nE 's/.*#[[:space:]]*([A-Za-z0-9._-]+).*/\1/p')"
+            tag="$(printf '%s\n' "$line" | sed -nE 's/[^#]*#[[:space:]]*([A-Za-z0-9._/+-]+).*/\1/p')"
             checked=$((checked + 1))
 
             if [ -z "$tag" ]; then
@@ -113,7 +122,7 @@ jobs:
               fail=1; continue
             fi
             echo "✓ $OWNER_REPO@${sha:0:12} is honestly pinned to $tag"
-          done < <(grep -rhE "uses:[[:space:]]*${OWNER_REPO}/[^@]*@[0-9a-fA-F]{40}" .github/workflows/ 2>/dev/null || true)
+          done < <(grep -rhE "^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*${OWNER_REPO}/[^@]*@[0-9a-fA-F]{40}" .github/workflows/ 2>/dev/null || true)
 
           echo "Checked $checked first-party pin(s) against $OWNER_REPO tags."
           if [ "$fail" -ne 0 ]; then

--- a/.github/workflows/verify-pins.yml
+++ b/.github/workflows/verify-pins.yml
@@ -1,0 +1,122 @@
+name: Verify Action Pins (Callable)
+# Reusable workflow that verifies first-party `praetorian-inc/public-workflows`
+# `uses:` pins in the CALLER's workflows are honest:
+#   (1) every pinned 40-char SHA carries a version comment (`# vX.Y.Z`),
+#   (2) that tag actually exists, and
+#   (3) the tag points at EXACTLY that SHA.
+#
+# Prevents the "lying pin comment" failure mode — a hand-edited `@<sha>  # vX.Y.Z`
+# where the tag doesn't exist or resolves to a different commit. A lying label
+# defeats audits and Dependabot and masks real pin divergence across a fleet.
+#
+# Scope: first-party public-workflows pins only (that is the recurrence we are
+# guarding). Third-party pins (actions/checkout, etc.) are out of scope — verifying
+# those needs cross-repo tag lookups and is better handled by Dependabot/zizmor.
+#
+# Caller example (.github/workflows/verify-pins.yml):
+#
+#   name: Verify Pins
+#   on:
+#     pull_request: { paths: ['.github/workflows/**'] }
+#     push: { branches: [main], paths: ['.github/workflows/**'] }
+#   permissions:
+#     contents: read
+#   jobs:
+#     verify:
+#       uses: praetorian-inc/public-workflows/.github/workflows/verify-pins.yml@<SHA>  # <tag>
+#       permissions:
+#         contents: read
+
+on:
+  workflow_call:
+    inputs:
+      owner-repo:
+        description: "First-party repo whose tags the pins are verified against."
+        required: false
+        type: string
+        default: "praetorian-inc/public-workflows"
+
+      enable-harden-runner:
+        description: "Whether to install StepSecurity Harden-Runner."
+        required: false
+        type: boolean
+        default: true
+
+      harden-runner-policy:
+        description: "Harden-Runner egress policy: 'audit' or 'block'."
+        required: false
+        type: string
+        default: "audit"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-pins:
+    name: Verify Action Pins
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          disable-sudo-and-containers: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify first-party pins
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER_REPO: ${{ inputs.owner-repo }}
+        run: |
+          set -euo pipefail
+          fail=0
+          checked=0
+
+          # Every line that pins OWNER_REPO to a 40-char SHA (comment kept for parsing).
+          while IFS= read -r line; do
+            sha="$(printf '%s\n' "$line" | sed -nE 's/.*@([0-9a-fA-F]{40}).*/\1/p')"
+            [ -n "$sha" ] || continue
+            tag="$(printf '%s\n' "$line" | sed -nE 's/.*#[[:space:]]*([A-Za-z0-9._-]+).*/\1/p')"
+            checked=$((checked + 1))
+
+            if [ -z "$tag" ]; then
+              echo "::error::$OWNER_REPO is pinned to @$sha with no version comment. Add '# vX.Y.Z'."
+              fail=1; continue
+            fi
+
+            # Resolve tag -> commit SHA (dereference annotated tags).
+            # gh api exits non-zero on 404, so a missing tag is caught cleanly here
+            # rather than letting the 404 body leak into the parsed value.
+            if ! ref_json="$(gh api "repos/$OWNER_REPO/git/ref/tags/$tag" 2>/dev/null)"; then
+              echo "::error::Pin comment '# $tag' (for $OWNER_REPO@$sha) names a tag that does not exist."
+              fail=1; continue
+            fi
+            otype="$(printf '%s' "$ref_json" | jq -r '.object.type')"
+            osha="$(printf '%s' "$ref_json" | jq -r '.object.sha')"
+            if [ "$otype" = "tag" ]; then
+              csha="$(gh api "repos/$OWNER_REPO/git/tags/$osha" --jq '.object.sha')"
+            else
+              csha="$osha"
+            fi
+
+            if [ "$csha" != "$sha" ]; then
+              echo "::error::Pin mismatch: $OWNER_REPO@$sha is commented '# $tag', but $tag points at $csha."
+              fail=1; continue
+            fi
+            echo "✓ $OWNER_REPO@${sha:0:12} is honestly pinned to $tag"
+          done < <(grep -rhE "uses:[[:space:]]*${OWNER_REPO}/[^@]*@[0-9a-fA-F]{40}" .github/workflows/ 2>/dev/null || true)
+
+          echo "Checked $checked first-party pin(s) against $OWNER_REPO tags."
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::One or more first-party pin comments are dishonest. Fix the SHA or the version comment."
+            exit 1
+          fi


### PR DESCRIPTION
## Why

The secrets-scan review found a fleet-wide pin-integrity defect: every Titus caller carried a `# v2.2.1` comment over a SHA, but **`v2.2.1` never existed** (tags jumped v2.2.0 → v2.3.0), and one repo pinned a divergent commit under the same fictional label. A lying pin comment defeats audits and Dependabot and masks real divergence.

This adds a reusable that makes such a comment **impossible to merge**.

## What it does

`verify-pins.yml` scans the caller's `.github/workflows/**` and, for every first-party `praetorian-inc/public-workflows/...@<40-hex-sha>` pin, asserts:

1. the SHA carries a version comment (`# vX.Y.Z`),
2. that tag exists, and
3. the tag points at **exactly** that SHA.

Any violation fails the job with a precise `::error::`. Scope is deliberately first-party only (the recurrence we're guarding); third-party pins stay with Dependabot/zizmor.

## Caller usage

```yaml
# .github/workflows/verify-pins.yml
name: Verify Pins
on:
  pull_request: { paths: ['.github/workflows/**'] }
  push: { branches: [main], paths: ['.github/workflows/**'] }
permissions:
  contents: read
jobs:
  verify:
    uses: praetorian-inc/public-workflows/.github/workflows/verify-pins.yml@<SHA>  # <tag>
    permissions:
      contents: read
```

Needs only `contents: read` + the default `GITHUB_TOKEN` (public-workflows tags are public). Harden-Runner enabled (audit).

## Validation

- `actionlint` (incl. shellcheck): **0 findings**.
- Red-green tested against the live API: an honest pin (`@ba1070e # v2.5.1`) **passes**; a fictional tag (`# v2.2.1`) fails with `tag does not exist`; a comment-less pin fails with `no version comment`.

## Rollout

After this merges and auto-tags, the 19 Titus callers will adopt it in the same PR that re-pins them to the real `v2.5.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
