### PR TITLE
fix(go-sec): visibility-gate SARIF upload + opt-in fail-on-findings (fixes no-GHAS private-repo 403s)

### DIFF
--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -22,12 +22,26 @@ name: Go Sec (Callable)
 #
 #   jobs:
 #     security:
-#       uses: praetorian-inc/public-workflows/.github/workflows/go-sec.yml@<SHA>  # v2.0.12
+#       uses: praetorian-inc/public-workflows/.github/workflows/go-sec.yml@<SHA>  # vX.Y.Z
 #       permissions:
 #         contents: read
-#         security-events: write  # required when upload-sarif: true (default)
-#         actions: read           # required by codeql-action/upload-sarif for run metadata
-#       secrets: inherit
+#         security-events: write  # gosec/govulncheck jobs statically declare it — grant even on private repos (else startup_failure)
+#         actions: read           # gosec/govulncheck jobs statically declare it — grant even on private repos (else startup_failure)
+#
+# Posture (safe by default — a caller of ANY visibility can copy the block above verbatim):
+#   - SARIF is uploaded to the Security tab ONLY on public repos (GitHub code scanning
+#     is free there). On private/internal repos the upload is auto-skipped — no GitHub
+#     Advanced Security required, and no false-red CI from a 403. The scan still runs;
+#     findings print to the job log.
+#   - A private/internal repo that HAS a GHAS license can opt back in with
+#     `with: { force-upload-private: true }`.
+#   - Scanning is observe-only by default (go-sec's historical posture). To make findings
+#     FAIL the build — recommended on private/no-GHAS repos where the Security tab is
+#     unavailable — pass `with: { fail-on-findings: true }`.
+#   - Grant security-events:write + actions:read regardless of visibility: the jobs
+#     statically declare them, so omitting them re-triggers a startup_failure even when
+#     the upload is skipped at runtime.
+#   - No `secrets: inherit` needed — this reusable only uses the auto-granted GITHUB_TOKEN.
 #
 # Design rationale: gosec+govulncheck live in their own reusable workflow
 # (separate from go-ci.yml) because
@@ -90,10 +104,22 @@ on:
         default: "./..."
 
       upload-sarif:
-        description: "Whether to upload SARIF findings to the GitHub Security tab. When true, the caller MUST grant both 'security-events: write' (to upload SARIF) AND 'actions: read' (for codeql-action/upload-sarif to fetch workflow run metadata). Missing 'actions: read' surfaces as 'Resource not accessible by integration' on the upload step even when the scan succeeds."
+        description: "Whether to upload SARIF findings to the GitHub Security tab. Auto-skipped on non-public repos unless force-upload-private is set (GitHub code scanning requires GHAS on private/internal repos and 403s without it). When uploaded, the caller MUST grant both 'security-events: write' (to upload SARIF) AND 'actions: read' (for codeql-action/upload-sarif to fetch workflow run metadata). Missing 'actions: read' surfaces as 'Resource not accessible by integration' on the upload step even when the scan succeeds."
         required: false
         type: boolean
         default: true
+
+      force-upload-private:
+        description: "Upload SARIF even on private/internal repos. Requires a GitHub Advanced Security license on the repo (the upload step 403s without it). Default false: SARIF upload is auto-skipped on non-public repos so the scan runs clean without GHAS — findings surface in the job log, and fail-on-findings can gate the build."
+        required: false
+        type: boolean
+        default: false
+
+      fail-on-findings:
+        description: "Fail the job on gosec findings or govulncheck vulnerabilities (exit-code gate). Default false (observe-only — go-sec's historical posture: findings surface via the Security tab on public repos and via the job log everywhere). Set true to enforce a red build on findings — recommended on private/internal repos without GHAS, where the Security tab is unavailable and the red build is the only finding surface."
+        required: false
+        type: boolean
+        default: false
 
       enable-harden-runner:
         description: "Whether to install StepSecurity Harden-Runner as the first step of every job."
@@ -128,6 +154,7 @@ jobs:
       pull-requests: read
     outputs:
       has_go: ${{ steps.check.outputs.has_go }}
+      visibility: ${{ steps.repo.outputs.visibility }}
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
@@ -136,6 +163,21 @@ jobs:
           egress-policy: ${{ inputs.harden-runner-policy }}
           allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
           disable-sudo-and-containers: true
+
+      # Resolve repo visibility via the API (reliable on push/PR/schedule/dispatch,
+      # unlike github.event.repository.visibility which is absent on some events).
+      # Drives whether SARIF upload is attempted — never gates the scan itself.
+      - name: Resolve repository visibility
+        id: repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eu
+          VIS=$(gh api "repos/$REPO" --jq '.visibility' 2>/dev/null || echo "")
+          [ -n "$VIS" ] || VIS="unknown"
+          echo "visibility=$VIS" >> "$GITHUB_OUTPUT"
+          echo "Repository visibility: $VIS"
 
       - name: Check for Go changes
         id: check
@@ -215,10 +257,36 @@ jobs:
 
       - name: Run gosec
         working-directory: ${{ inputs.working-directory }}
-        run: gosec ${{ inputs.gosec-args }}
+        shell: bash
+        env:
+          GOSEC_ARGS: ${{ inputs.gosec-args }}
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
+        run: |
+          ARGS="$GOSEC_ARGS"
+          # When enforcing, strip -no-fail so gosec's non-zero exit on findings
+          # gates the build (the SARIF file is still written first, so the
+          # always() upload below still has a valid artifact on public repos).
+          # When NOT enforcing, ARGS is passed through verbatim — preserving the
+          # exit code a caller who removed -no-fail via gosec-args already relied on.
+          if [ "$FAIL_ON_FINDINGS" = "true" ]; then
+            ARGS="${ARGS//-no-fail/}"
+          fi
+          # shellcheck disable=SC2086
+          gosec $ARGS
 
+      # Announce (don't silently swallow) when upload is skipped on a non-public repo.
+      - name: Note gosec SARIF upload skipped
+        if: ${{ always() && inputs.upload-sarif && needs.preflight.outputs.visibility != 'public' && !inputs.force-upload-private }}
+        env:
+          VIS: ${{ needs.preflight.outputs.visibility }}
+        run: |
+          echo "::notice::gosec SARIF upload skipped — repository visibility is '$VIS' (not public; GitHub code scanning needs GHAS on private/internal repos). The scan ran and findings are in the job log above. Set fail-on-findings:true to gate the build on findings, or enable GHAS and pass with:{ force-upload-private: true } to upload to the Security tab."
+
+      # Upload only when requested AND the repo can accept it: public repos (code
+      # scanning is free) or a private repo that opted in via force-upload-private.
+      # Prevents the GHAS 403 that turns a clean private-repo scan into a false-red.
       - name: Upload gosec SARIF
-        if: ${{ inputs.upload-sarif && always() }}
+        if: ${{ always() && inputs.upload-sarif && (needs.preflight.outputs.visibility == 'public' || inputs.force-upload-private) }}
         uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0  # v4.35.2
         with:
           sarif_file: ${{ inputs.working-directory }}/gosec-results.sarif
@@ -259,10 +327,15 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@${{ inputs.govulncheck-version }}
 
+      # SARIF mode runs only when the result will actually be uploaded (public
+      # repo, or private repo that opted in via force-upload-private). Otherwise
+      # the text-mode step below runs instead — its findings surface in the log.
       - name: Run govulncheck (SARIF)
-        if: ${{ inputs.upload-sarif }}
+        if: ${{ inputs.upload-sarif && (needs.preflight.outputs.visibility == 'public' || inputs.force-upload-private) }}
         working-directory: ${{ inputs.working-directory }}
         shell: bash
+        env:
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
         # govulncheck exits 0 on clean, 3 on vulns-found, other on error. Under
         # the default `bash -e` shell, exit 3 aborts the step mid-pipe and can
         # leave govulncheck-results.sarif empty or truncated; the subsequent
@@ -290,30 +363,55 @@ jobs:
           }
           SARIF_EOF
           fi
+          # Gate on vulnerabilities (exit 3) only when enforcing. The SARIF file
+          # is already written/validated above, so the always() upload below
+          # still has a valid artifact even when we fail the step here.
+          if [ "$FAIL_ON_FINDINGS" = "true" ] && [ "$EXIT" -eq 3 ]; then
+            echo "::error::govulncheck found vulnerabilities (exit=3) and fail-on-findings is enabled."
+            exit "$EXIT"
+          fi
           # Propagate genuine tool errors (exit 1,2) — but treat "vulns found"
           # (exit 3) as success for CI purposes; findings surface via SARIF
           # upload to the GitHub Security tab. Keeps security scanning
           # non-blocking on build pipelines, per design rationale at top of file.
-          if [ $EXIT -ne 0 ] && [ $EXIT -ne 3 ]; then
+          if [ "$EXIT" -ne 0 ] && [ "$EXIT" -ne 3 ]; then
             echo "::error::govulncheck tooling error (exit=$EXIT)"
-            exit $EXIT
+            exit "$EXIT"
           fi
 
+      # Text mode runs when SARIF won't be uploaded (private/internal repo without
+      # GHAS, or upload-sarif:false). Findings print to the job log — the finding
+      # surface when the Security tab is unavailable.
       - name: Run govulncheck (text)
-        if: ${{ !inputs.upload-sarif }}
+        if: ${{ !(inputs.upload-sarif && (needs.preflight.outputs.visibility == 'public' || inputs.force-upload-private)) }}
         working-directory: ${{ inputs.working-directory }}
-        # Same rationale as SARIF branch: exit 3 = vulns found; don't fail the step.
         shell: bash
+        env:
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
         run: |
           set +e
           govulncheck ${{ inputs.govulncheck-package }}
           EXIT=$?
-          if [ $EXIT -ne 0 ] && [ $EXIT -ne 3 ]; then
-            exit $EXIT
+          echo "govulncheck exit code: $EXIT"
+          # exit 3 = vulns found. Gate the build only when enforcing.
+          if [ "$FAIL_ON_FINDINGS" = "true" ] && [ "$EXIT" -eq 3 ]; then
+            echo "::error::govulncheck found vulnerabilities (exit=3) and fail-on-findings is enabled."
+            exit "$EXIT"
+          fi
+          # Propagate genuine tool errors (not clean=0, not vulns=3).
+          if [ "$EXIT" -ne 0 ] && [ "$EXIT" -ne 3 ]; then
+            exit "$EXIT"
           fi
 
+      - name: Note govulncheck SARIF upload skipped
+        if: ${{ always() && inputs.upload-sarif && needs.preflight.outputs.visibility != 'public' && !inputs.force-upload-private }}
+        env:
+          VIS: ${{ needs.preflight.outputs.visibility }}
+        run: |
+          echo "::notice::govulncheck SARIF upload skipped — repository visibility is '$VIS' (not public; GitHub code scanning needs GHAS on private/internal repos). govulncheck ran in text mode; findings are in the job log above. Set fail-on-findings:true to gate the build, or enable GHAS and pass with:{ force-upload-private: true }."
+
       - name: Upload govulncheck SARIF
-        if: ${{ inputs.upload-sarif && always() }}
+        if: ${{ always() && inputs.upload-sarif && (needs.preflight.outputs.visibility == 'public' || inputs.force-upload-private) }}
         uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0  # v4.35.2
         with:
           sarif_file: ${{ inputs.working-directory }}/govulncheck-results.sarif


### PR DESCRIPTION
## Why

`go-sec.yml` (gosec + govulncheck) defaults `upload-sarif: true` with **no repository-visibility guard**. On private/internal repos **without GitHub Advanced Security**, the `codeql-action/upload-sarif` step 403s — *"Code Security must be enabled for this repository to use code scanning"* — turning a clean scan into a **false-red build**. This is the exact failure `titus-scan.yml` already solved in v2.5.1 (Stage 2). It is currently breaking the `Security` workflow on **probus, florian, caligula, nero** (internal, no GHAS).

This ports the titus visibility-gate pattern into `go-sec.yml` and adds an opt-in enforcement gate.

## What changed (behavior-preserving by default)

1. **Preflight resolves repo visibility** (`gh api repos/$REPO --jq .visibility`) — same step titus uses; reliable across push/PR/schedule/dispatch.
2. **SARIF upload is visibility-gated** (both gosec + govulncheck): upload only when `visibility == 'public' || force-upload-private`. A `::notice::` is emitted when skipped (non-silent). New input **`force-upload-private`** (default false) lets a GHAS-licensed private repo opt back in.
3. **govulncheck mode follows the upload decision**: SARIF mode when the result will be uploaded, otherwise **text mode** so findings still print to the job log on no-GHAS repos.
4. **New opt-in input `fail-on-findings`** (default false — preserves go-sec's historical observe-only posture). When true, gosec drops `-no-fail` and govulncheck treats exit 3 (vulns found) as a failure, so the **red build is the finding surface** on repos where the Security tab is unavailable.
5. Header caller-example updated (posture docs; `security-events`/`actions` required regardless of visibility because the jobs statically declare them; no `secrets: inherit` needed — only GITHUB_TOKEN is used).

## Blast-radius analysis (verified by tracing every `if:` for each caller class)

| Caller class | Before | After |
|---|---|---|
| **Public** (titus, capability-sdk, augustus, nerva, vespasian, julius) | upload SARIF | **unchanged** — visibility=public → uploads exactly as before |
| **Private, default** (probus, florian, caligula) | ❌ 403 false-red | ✅ upload auto-skipped + `::notice::`, govulncheck → text mode, **green**; findings in log |
| **Private, `upload-sarif:false`** (pertinax) | green (no upload) | **unchanged** — still green |
| **Any repo, `fail-on-findings:true`** (opt-in) | n/a | gosec/govulncheck **gate the build** on findings |

`nero` will still fail after this change for an **unrelated** reason (gosec "No packages found" + govulncheck tool error, exit 1) — that's a real package-layout issue tracked separately, not the GHAS 403.

## Follow-up (separate PRs, after this merges + is tagged)

- Re-pin all `go-sec.yml` callers to the new tag — also fixes current **pin drift** (callers scattered across v2.1.0 / v2.2.0 / v2.3.1 / v2.4.1).
- For the no-GHAS internal repos, the re-pin can also pass `fail-on-findings: true` if we want SAST to gate there (recommended; currently observe-only).

## Validation
- `actionlint` clean on all added shell (the lone SC2001 is the pre-existing `sed 's/^/  /'` in the Go-changes preflight, unchanged).
- YAML parses; every job `if:` traced for all four caller classes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
