### PR TITLE
fix(ci): go-sec no-Go-sources guard (nero) + repair go-sec/ts-ci self-test harnesses

### DIFF
--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -154,6 +154,7 @@ jobs:
       pull-requests: read
     outputs:
       has_go: ${{ steps.check.outputs.has_go }}
+      has_go_sources: ${{ steps.gosrc.outputs.has_go_sources }}
       visibility: ${{ steps.repo.outputs.visibility }}
     steps:
       - name: Harden Runner
@@ -178,6 +179,43 @@ jobs:
           [ -n "$VIS" ] || VIS="unknown"
           echo "visibility=$VIS" >> "$GITHUB_OUTPUT"
           echo "Repository visibility: $VIS"
+
+      # Detect whether the repository contains ANY Go sources (go.mod or *.go),
+      # anywhere in the tree — not just under working-directory. A repo with zero
+      # Go (e.g. a freshly-created capability skeleton like nero) has nothing to
+      # scan: gosec exits 1 with "No packages found" (which -no-fail does NOT
+      # suppress) and govulncheck errors "no go.mod file". We skip both jobs
+      # cleanly instead of red-failing. Whole-repo scope is deliberate: if Go
+      # exists somewhere but NOT under working-directory, that is a
+      # misconfiguration we must NOT mask — gosec is left to surface "No packages
+      # found" there. Fail-safe: on any API error or a truncated tree we assume
+      # Go is present and scan (never skip on uncertainty).
+      - name: Detect Go sources in repository
+        id: gosrc
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -eu
+          RESP=$(gh api "repos/$REPO/git/trees/$SHA?recursive=1" 2>/dev/null || echo "")
+          if [ -z "$RESP" ]; then
+            echo "has_go_sources=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Could not enumerate the repository tree — assuming Go sources are present and scanning."
+            exit 0
+          fi
+          TRUNCATED=$(printf '%s' "$RESP" | jq -r '.truncated // false')
+          GO_COUNT=$(printf '%s' "$RESP" | jq '[.tree[]? | select(.type=="blob") | select(.path | test("(^|/)go\\.mod$|\\.go$"))] | length')
+          if [ "$TRUNCATED" = "true" ]; then
+            echo "has_go_sources=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Repository tree was truncated by the API — assuming Go sources are present and scanning."
+          elif [ "$GO_COUNT" -gt 0 ]; then
+            echo "has_go_sources=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Repository contains Go sources ($GO_COUNT go.mod/*.go entries) — security scan will run."
+          else
+            echo "has_go_sources=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Go sources (go.mod or *.go) found anywhere in the repository — skipping gosec/govulncheck. The jobs pass; scanning resumes automatically once Go files are added."
+          fi
 
       - name: Check for Go changes
         id: check
@@ -216,7 +254,7 @@ jobs:
   gosec:
     name: Gosec
     needs: preflight
-    if: needs.preflight.outputs.has_go == 'true' && inputs.enable-gosec
+    if: needs.preflight.outputs.has_go == 'true' && needs.preflight.outputs.has_go_sources == 'true' && inputs.enable-gosec
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -295,7 +333,7 @@ jobs:
   govulncheck:
     name: Govulncheck
     needs: preflight
-    if: needs.preflight.outputs.has_go == 'true' && inputs.enable-govulncheck
+    if: needs.preflight.outputs.has_go == 'true' && needs.preflight.outputs.has_go_sources == 'true' && inputs.enable-govulncheck
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/test-go-sec.yml
+++ b/.github/workflows/test-go-sec.yml
@@ -31,6 +31,9 @@ jobs:
     uses: ./.github/workflows/go-sec.yml
     permissions:
       contents: read
+      pull-requests: read     # go-sec.yml preflight reads PR files + repo tree
+      security-events: write  # gosec/govulncheck jobs statically declare it — grant even with upload-sarif:false, else startup_failure
+      actions: read           # required by codeql-action/upload-sarif metadata fetch
     with:
       working-directory: _test-fixtures/go-minimal
       upload-sarif: false
@@ -40,6 +43,9 @@ jobs:
     uses: ./.github/workflows/go-sec.yml
     permissions:
       contents: read
+      pull-requests: read     # go-sec.yml preflight reads PR files + repo tree
+      security-events: write  # gosec/govulncheck jobs statically declare it — grant even with upload-sarif:false, else startup_failure
+      actions: read           # required by codeql-action/upload-sarif metadata fetch
     with:
       working-directory: _test-fixtures/go-minimal
       enable-govulncheck: false
@@ -50,6 +56,9 @@ jobs:
     uses: ./.github/workflows/go-sec.yml
     permissions:
       contents: read
+      pull-requests: read     # go-sec.yml preflight reads PR files + repo tree
+      security-events: write  # gosec/govulncheck jobs statically declare it — grant even with upload-sarif:false, else startup_failure
+      actions: read           # required by codeql-action/upload-sarif metadata fetch
     with:
       working-directory: _test-fixtures/go-minimal
       enable-gosec: false

--- a/.github/workflows/test-ts-ci.yml
+++ b/.github/workflows/test-ts-ci.yml
@@ -24,7 +24,6 @@ permissions:
 jobs:
   call-ts-ci-defaults:
     name: Call ts-ci (defaults)
-    timeout-minutes: 20
     uses: ./.github/workflows/ts-ci.yml
     permissions:
       contents: read
@@ -33,7 +32,6 @@ jobs:
 
   call-ts-ci-test-only:
     name: Call ts-ci (test only, no lint/typecheck)
-    timeout-minutes: 20
     uses: ./.github/workflows/ts-ci.yml
     permissions:
       contents: read


### PR DESCRIPTION
## What

Three CI-correctness fixes in public-workflows:

### 1. go-sec.yml — skip cleanly when a repo has no Go sources (nero fix)
A repo with zero Go (e.g. the `nero` skeleton: only `.github`, no `go.mod`/`*.go`) makes gosec exit 1 (`No packages found` — **`-no-fail` does not suppress this**) and govulncheck error (`no go.mod file`). New preflight step `Detect Go sources in repository` scans the **whole repo tree** for `go.mod`/`*.go`; both jobs are gated on `has_go_sources == true` and skip cleanly otherwise.
- **Whole-repo scope is deliberate:** if Go exists but not under `working-directory`, that is a misconfiguration we must NOT mask — gosec still surfaces `No packages found` there.
- **Fail-safe:** on any API error or a truncated tree, assume Go is present and scan (never skip on uncertainty).

### 2. test-go-sec.yml — repair the self-test harness
Its jobs granted only `contents: read`, but go-sec.yml statically declares `pull-requests: read` + `security-events: write` + `actions: read` → every self-test run was a **startup_failure** and never actually tested go-sec.yml. Grant the full union.

### 3. test-ts-ci.yml — fix startup_failure
`timeout-minutes` is not valid on a reusable-calling job (only name/uses/with/secrets/needs/if/permissions) → invalid file → **startup_failure on every run since 2026-06-02**. Removed the two lines.

## Verification
- actionlint clean on all three (only a pre-existing SC2001 style nit in go-sec.yml, shipped in every prior version).
- The self-test (test-go-sec.yml) and test-ts-ci.yml run on this PR — they should now go green for the first time, proving fixes #2 and #3.
- The no-Go-sources skip path (fix #1) is verified end-to-end against nero after re-pin (public-workflows is not an empty repo, so its self-test exercises the *has-Go* path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)