### PR TITLE
fix(go-sec): print gosec findings to the job log when SARIF upload is skipped

### DIFF
--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -309,8 +309,26 @@ jobs:
           if [ "$FAIL_ON_FINDINGS" = "true" ]; then
             ARGS="${ARGS//-no-fail/}"
           fi
+          set +e
           # shellcheck disable=SC2086
           gosec $ARGS
+          EXIT=$?
+          set -e
+          # Mirror findings from the SARIF file into the job log. gosec writes only
+          # SARIF (-fmt sarif -out ...), so on internal/private repos where the SARIF
+          # upload is skipped (no GHAS) the findings would otherwise be invisible —
+          # a red fail-on-findings build with zero detail. Printing them here keeps
+          # findings actionable everywhere (parallels govulncheck text-mode below),
+          # and surfaces them in observe-only mode too. Does not affect the exit code.
+          if [ -s gosec-results.sarif ]; then
+            COUNT=$(jq "[.runs[]?.results[]?] | length" gosec-results.sarif 2>/dev/null || echo 0)
+            if [ "$COUNT" -gt 0 ]; then
+              echo "::group::gosec findings ($COUNT)"
+              jq -r ".runs[]?.results[]? | \"\(.ruleId // \"?\") [\(.level // \"warning\")] \(.message.text // \"\") — \(.locations[0].physicalLocation.artifactLocation.uri // \"?\"):\(.locations[0].physicalLocation.region.startLine // 0)\"" gosec-results.sarif 2>/dev/null || true
+              echo "::endgroup::"
+            fi
+          fi
+          exit "$EXIT"
 
       # Announce (don't silently swallow) when upload is skipped on a non-public repo.
       - name: Note gosec SARIF upload skipped


### PR DESCRIPTION
## Why
On internal/private repos without GHAS, gosec SARIF upload is (correctly) skipped — but gosec runs `-fmt sarif -out`, so its findings went to a file that is never shown. A `fail-on-findings: true` build would go **red with zero detail**. (govulncheck already falls back to text mode; gosec did not — asymmetry found while rolling out fail-on-findings on florian/probus.)

## What
After gosec runs, mirror the SARIF results into the job log inside a `::group::` (ruleId, level, message, file:line). Visible in both observe-only and fail-on-findings modes, on every repo visibility. **Exit code unchanged** (gating preserved via captured $EXIT).

## Verification
- actionlint clean (only the pre-existing SC2001 style nit).
- jq print logic verified against a sample gosec SARIF (below).
- Self-test (go-minimal) confirms no regression on the clean/happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)