### PR TITLE
fix(claude): bump claude-code-action v1.0.101 → v1.0.135 (opus-4-8 adaptive-thinking API)

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Run Claude PR Action
         id: claude-review
-        uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009  # v1.0.101
+        uses: anthropics/claude-code-action@e34df8781c2370c1c9d3b83ae47286a7ae2d1ea6  # v1.0.135
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -233,7 +233,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Claude drift analysis
-        uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009  # v1.0.101
+        uses: anthropics/claude-code-action@e34df8781c2370c1c9d3b83ae47286a7ae2d1ea6  # v1.0.135
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## P0 — Claude PR review failing fleet-wide

**Symptom (proven):**
```
API Error 400 invalid_request_error: "thinking.type.enabled" is not supported
for this model. Use "thinking.type.adaptive" and "output_config.effort"
```
- guard `#5896` run `26933546068` (2026-06-04) — fail
- titus run `26905631621` (2026-06-03 18:44 UTC, req_011CbgpaUdCbB3Bg1iVsMzRj) — fail
- augustus/julius claude runs **succeeded 2026-06-02 22:28**; failures begin **2026-06-03 18:44** → server-side opus-4-8 rollout.

## Root cause
`claude-code-action@v1.0.101` (`38ec876`) bundles **Claude Code CLI 2.1.114**, which emits the deprecated `thinking.type.enabled` request shape. opus-4-8 now rejects that shape server-side.

Action → bundled CLI mapping (verified via `base-action/action.yml:CLAUDE_CODE_VERSION`):

| action | CLI | thinking shape |
|--------|-----|----------------|
| v1.0.101 (current pin) | 2.1.114 | `thinking.type.enabled` ❌ |
| v1.0.135 (this PR) | 2.1.162 | adaptive ✅ |

CLI 2.1.162 is the current `npm` latest and is **proven to drive opus-4-8 with adaptive thinking** (CHANGELOG 2.1.x: *"Fixed an issue when using Opus 4.8 where thinking blocks were modified, leading to API errors."*).

## Fix
Bump the action pin `v1.0.101 → v1.0.135` in both Claude-executing reusables:
- `claude-code.yml` (PR reviewer, `--model claude-opus-4-8`)
- `claude-md-drift.yml` (same stale pin; default model Haiku 4.5 but caller-overridable to opus-4-8)

## Compatibility
Verified `v1.0.135` `action.yml` retains every input/output this reusable consumes: `prompt`, `track_progress`, `claude_args`, `anthropic_api_key`, `github_token`, `outputs.execution_file`. **Drop-in.** No change to the hardened tool allowlist, model, or `track_progress: false`.

## Not applicable
Upstream `anthropics/claude-code-action#1265` is **Bedrock + Opus 4.7** — a different config from our direct-API + opus-4-8 path.

## Verification plan (post-merge)
1. Tag `v2.6.4`.
2. Sweep the claude pin in 37 caller repos to the new tag SHA.
3. **Gate:** a real code PR in ≥2 repos shows the `claude-code-action` job *executed (not skipped) + success* and a `## Claude Review` is posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)