### PR TITLE
chore(claude-md-drift): raise default max_turns 10 → 20

### DIFF
--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -56,7 +56,7 @@ on:
         description: "Maximum number of Claude conversation turns for drift analysis"
         required: false
         type: number
-        default: 10
+        default: 20
     secrets:
       ANTHROPIC_API_KEY:
         description: "Anthropic API key for Claude"


### PR DESCRIPTION
Raises the `max_turns` default in the callable `claude-md-drift.yml` reusable from **10 → 20**.

**Why:** gives the read-only drift agent (Haiku) headroom to read larger `CLAUDE.md` files plus scoped diffs before concluding, reducing premature truncation on bigger repos.

**Safety / cost:** read-only workflow (no Write/Edit/commit/push tools); model defaults to Haiku; pre-filter gates the LLM job on a relevant in-scope `CLAUDE.md` actually existing. Marginal cost impact negligible. Callers may still override `max_turns` per repo.

After merge: auto-tag will cut a new tag; the 25 drift callers will be swept to it so the new default is live fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)