### PR TITLE
fix(markdown-quality): grant preflight pull-requests:read for private repos

### DIFF
--- a/.github/workflows/markdown-quality.yml
+++ b/.github/workflows/markdown-quality.yml
@@ -19,6 +19,7 @@ name: Markdown Quality (Callable)
 #       uses: praetorian-inc/public-workflows/.github/workflows/markdown-quality.yml@<SHA>
 #       permissions:
 #         contents: read
+#         pull-requests: read   # preflight scopes checks to PRs that touch markdown
 #
 # For repos with a custom markdownlint config, place .markdownlint-cli2.jsonc
 # or .markdownlint.jsonc in the repo root. The workflow uses it automatically.
@@ -98,6 +99,13 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      # The "Check for markdown changes" step below calls
+      # `gh api repos/{repo}/pulls/{n}/files` to scope checks to PRs that touch
+      # markdown. On private/internal repos that endpoint requires pull-requests:read;
+      # without it gh returns HTTP 403 and the `set -eu` step fails the whole run.
+      # A reusable job's permissions block is the ceiling for its GITHUB_TOKEN, so
+      # this MUST be declared here — a caller grant alone cannot add the scope.
+      pull-requests: read
     outputs:
       has_md: ${{ steps.check.outputs.has_md }}
     steps:


### PR DESCRIPTION
## Problem

The `markdown-quality.yml` reusable workflow's **preflight** job fails on every PR in private/internal repos with HTTP 403.

The preflight step scopes quality checks to PRs that actually touch markdown by calling:

```sh
gh api repos/{repo}/pulls/{n}/files
```

On private/internal repos that endpoint requires the `pull-requests: read` scope. The preflight job declared only:

```yaml
permissions:
  contents: read
```

An explicit `permissions:` block defaults **all** unlisted scopes (including `pull-requests`) to `none`, so `gh api` 403s and the `set -eu` step fails the whole run.

## Why the caller can't fix it

A reusable job's own `permissions:` block is the **ceiling** for its `GITHUB_TOKEN` — a caller cannot add a scope the reusable job doesn't itself declare. Verified live: **guard-skills PR #20** still 403'd at preflight after granting `pull-requests: read` in the caller. The grant must live on the `preflight` job itself.

## Fix

- Add `pull-requests: read` to the `preflight` job's permissions.
- Document it in the caller-example comment block.

Purely additive. Public repos were unaffected (the PR-files endpoint is readable with the default token there). The `quality` job is unchanged — it only needs `contents: read` to checkout + run npx.

## Follow-up

After merge + tag, the **guard-skills** caller (PR #20) will be re-pinned to the new SHA so its markdown gate goes green on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)