### PR TITLE
chore(claude-md-drift): raise max_turns default 30 → 45

### DIFF
--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -56,7 +56,7 @@ on:
         description: "Maximum number of Claude conversation turns for drift analysis"
         required: false
         type: number
-        default: 30
+        default: 45
     secrets:
       ANTHROPIC_API_KEY:
         description: "Anthropic API key for Claude"


### PR DESCRIPTION
## What

Bumps the `max_turns` input default in `claude-md-drift.yml` from **30 → 45**.

## Why

The Haiku drift analysis hits `error_max_turns` ("Reached maximum number of turns (30)") on large PRs. Observed on [augustus #131](https://github.com/praetorian-inc/augustus/pull/131) — a 45-changed-code-file PR where the **same** analysis passed on one run and hit the 30-turn cap on the next (non-deterministic boundary). The changed-file scope was identical across runs, so this is a budget issue, not a detection regression.

45 gives headroom on big PRs; small PRs finish well under the cap and are unaffected. Callers passing an explicit `max_turns` still override.

## Note

Callers that pin an explicit `max_turns: 30` (e.g. augustus) must update their caller (or drop the override to inherit this new default) to benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)