### PR TITLE
feat: add skill-quality reusable workflow (agentskills.io frontmatter validation)

### DIFF
--- a/.github/workflows/skill-quality.yml
+++ b/.github/workflows/skill-quality.yml
@@ -1,0 +1,280 @@
+name: Skill Quality (Callable)
+# Reusable workflow that validates Agent Skill `SKILL.md` frontmatter against the
+# agentskills.io specification (https://agentskills.io/specification) plus the
+# Praetorian extensions (`tags`, `related`) that guard-core's skill loader reads.
+#
+# Why this exists: a malformed frontmatter block does NOT produce an error in
+# guard-core's loader — it is silently skipped (LoadSkillMetadata returns nil on
+# parse failure), so the skill simply disappears from the platform with no log.
+# Prettier-only markdown CI does not parse frontmatter (embeddedLanguageFormatting
+# is off), so this class of bug is otherwise uncaught until a human notices a
+# missing skill. This workflow makes invalid frontmatter a hard CI failure.
+#
+# Designed for skill repos with no package.json (e.g. guard-skills). Each
+# immediate subdirectory with a SKILL.md is one skill; dirs starting with `_` or
+# `.` (templates, dev-time `.local`/`.history`) are skipped.
+#
+# Caller example (drop in .github/workflows/skill-quality.yml):
+#
+#   name: Skill Quality
+#   on:
+#     push: { branches: [main] }
+#     pull_request: { branches: [main] }
+#   permissions:
+#     contents: read
+#   jobs:
+#     validate:
+#       uses: praetorian-inc/public-workflows/.github/workflows/skill-quality.yml@<SHA>  # <tag>
+#       permissions:
+#         contents: read
+#
+# Local pre-commit equivalent: templates/skills/validate-skills.py (kept in sync
+# with the inlined validator below).
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: "Directory containing the skill subdirectories."
+        required: false
+        type: string
+        default: "."
+
+      skills-glob:
+        description: "Glob (relative to working-directory) matching each skill's SKILL.md."
+        required: false
+        type: string
+        default: "*/SKILL.md"
+
+      python-version:
+        description: "Python version for the validator."
+        required: false
+        type: string
+        default: "3.12"
+
+      jsonschema-version:
+        description: "Pinned jsonschema version. Never use 'latest'."
+        required: false
+        type: string
+        default: "4.25.1"
+
+      pyyaml-version:
+        description: "Pinned PyYAML version. Never use 'latest'."
+        required: false
+        type: string
+        default: "6.0.2"
+
+      tag-vocabulary:
+        description: "Comma-separated controlled vocabulary for the `tags` extension."
+        required: false
+        type: string
+        default: "web,cloud,cicd,llm,cred"
+
+      enable-harden-runner:
+        description: "Enable StepSecurity Harden-Runner as the first step."
+        required: false
+        type: boolean
+        default: true
+
+      harden-runner-policy:
+        description: "Harden-Runner egress policy: 'audit' or 'block'."
+        required: false
+        type: string
+        default: "audit"
+
+      harden-runner-allowed-endpoints:
+        description: "Newline-separated allowed endpoints for block mode (e.g. pypi.org:443, files.pythonhosted.org:443)."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      has_skill: ${{ steps.check.outputs.has_skill }}
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+          disable-sudo-and-containers: true
+
+      - name: Check for SKILL.md changes
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+
+          # Non-PR events (push to main, schedule, dispatch) always run.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "has_skill=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Non-PR event ($EVENT_NAME) — skill validation will run."
+            exit 0
+          fi
+
+          # Detect changed files via the commits compare API, which needs only
+          # `contents: read`. Fail open (run) if the call fails — same rationale
+          # as markdown-quality.yml.
+          if ! FILES=$(gh api "repos/$REPO/compare/$BASE_SHA...$HEAD_SHA" --jq '.files[]?.filename' 2>/dev/null); then
+            echo "has_skill=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Could not list changed files (compare API error) — running validation to be safe."
+            exit 0
+          fi
+          COUNT=$(printf '%s\n' "$FILES" | grep -c . || true)
+
+          # The compare endpoint caps `.files` at 300; on a larger diff fail open.
+          if [ "$COUNT" -ge 300 ]; then
+            echo "has_skill=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Large diff (>=300 changed files) — running validation to be safe."
+            exit 0
+          fi
+
+          # Run when any SKILL.md changed, or when this workflow itself changed.
+          if printf '%s\n' "$FILES" | grep -qE '(^|/)SKILL\.md$|\.github/workflows/skill-quality\.yml$'; then
+            echo "has_skill=true" >> "$GITHUB_OUTPUT"
+            echo "✓ SKILL.md (or workflow) changes detected — validation will run."
+          else
+            echo "has_skill=false" >> "$GITHUB_OUTPUT"
+            echo "⊘ No SKILL.md changes — validation will be skipped."
+          fi
+
+  validate:
+    name: Validate skill frontmatter
+    needs: preflight
+    if: needs.preflight.outputs.has_skill == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable-harden-runner }}
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ inputs.harden-runner-policy }}
+          allowed-endpoints: ${{ inputs.harden-runner-allowed-endpoints }}
+          disable-sudo-and-containers: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install validator dependencies
+        env:
+          JSONSCHEMA_VERSION: ${{ inputs.jsonschema-version }}
+          PYYAML_VERSION: ${{ inputs.pyyaml-version }}
+        run: pip install "jsonschema==${JSONSCHEMA_VERSION}" "PyYAML==${PYYAML_VERSION}"
+
+      - name: Validate SKILL.md frontmatter
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          SKILLS_GLOB: ${{ inputs.skills-glob }}
+          TAG_VOCABULARY: ${{ inputs.tag-vocabulary }}
+        run: |
+          # Inlined validator — kept in sync with templates/skills/validate-skills.py.
+          # Single source for CI so the check is atomically versioned with this @SHA.
+          python3 - <<'PY'
+          import sys, os, glob
+          import yaml
+          from jsonschema import Draft202012Validator
+
+          skills_glob = os.environ.get("SKILLS_GLOB", "*/SKILL.md")
+          tag_vocab = [t.strip() for t in os.environ.get(
+              "TAG_VOCABULARY", "web,cloud,cicd,llm,cred").split(",") if t.strip()]
+
+          # agentskills.io core (https://agentskills.io/specification) + Praetorian
+          # extensions `tags` and `related`. additionalProperties:false catches
+          # frontmatter key typos (e.g. `descriptoin:`, `tag:`).
+          schema = {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "additionalProperties": False,
+              "required": ["name", "description"],
+              "properties": {
+                  "name": {"type": "string", "maxLength": 64,
+                           "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"},
+                  "description": {"type": "string", "minLength": 1, "maxLength": 1024},
+                  "license": {"type": "string"},
+                  "compatibility": {"type": "string", "maxLength": 500},
+                  "metadata": {"type": "object", "additionalProperties": {"type": "string"}},
+                  "allowed-tools": {"type": "string"},
+                  "tags": {"type": "array", "minItems": 1, "items": {"enum": tag_vocab}},
+                  "related": {"type": "array", "items": {"type": "string"}},
+              },
+          }
+          validator = Draft202012Validator(schema)
+
+          def frontmatter(path):
+              txt = open(path, encoding="utf-8").read()
+              if not txt.startswith("---\n"):
+                  raise ValueError("missing leading '---' frontmatter")
+              parts = txt[4:].split("\n---\n", 1)
+              if len(parts) != 2:
+                  raise ValueError("unterminated frontmatter (no closing '---')")
+              return yaml.safe_load(parts[0])
+
+          files = sorted(
+              f for f in glob.glob(skills_glob)
+              if not os.path.basename(os.path.dirname(f)).startswith(("_", "."))
+          )
+          errors = []
+          for f in files:
+              d = os.path.basename(os.path.dirname(f))
+              try:
+                  fm = frontmatter(f)
+              except Exception as e:
+                  errors.append(f"{f}: invalid frontmatter — {e}")
+                  continue
+              if not isinstance(fm, dict):
+                  errors.append(f"{f}: frontmatter is not a mapping")
+                  continue
+              for err in sorted(validator.iter_errors(fm), key=lambda e: list(e.path)):
+                  loc = ".".join(map(str, err.path)) or "(root)"
+                  errors.append(f"{f}: [{loc}] {err.message}")
+              # Procedural checks the JSON Schema cannot express:
+              if isinstance(fm.get("name"), str) and fm["name"] != d:
+                  errors.append(f"{f}: name '{fm['name']}' must equal parent directory '{d}' (agentskills.io)")
+              at = fm.get("allowed-tools")
+              if isinstance(at, str) and "," in at:
+                  errors.append(f"{f}: allowed-tools must be space-separated, not comma — got '{at}'")
+
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          lines = [f"## Skill Quality\n\nValidated **{len(files)}** skill(s) matching `{skills_glob}` "
+                   f"(excluding `_*` / `.*` dirs).\n"]
+          if errors:
+              lines.append(f"\n❌ **{len(errors)} problem(s):**\n")
+              lines += [f"- `{e}`" for e in errors]
+          else:
+              lines.append("\n✅ All skills conform to the agentskills.io core schema + Praetorian extensions.")
+          if summary:
+              with open(summary, "a", encoding="utf-8") as fh:
+                  fh.write("\n".join(lines) + "\n")
+
+          if errors:
+              print(f"::error::{len(errors)} skill frontmatter problem(s) found")
+              for e in errors:
+                  print(f"  - {e}")
+              print("\nFix locally with: python3 <repo>/templates/skills/validate-skills.py")
+              sys.exit(1)
+          print(f"✓ {len(files)} skill(s) valid")
+          PY

--- a/.github/workflows/skill-quality.yml
+++ b/.github/workflows/skill-quality.yml
@@ -225,19 +225,29 @@ jobs:
           validator = Draft202012Validator(schema)
 
           def frontmatter(path):
-              txt = open(path, encoding="utf-8").read()
+              # utf-8-sig strips a leading BOM; text mode normalizes CRLF/CR.
+              with open(path, encoding="utf-8-sig") as fh:
+                  txt = fh.read()
               if not txt.startswith("---\n"):
                   raise ValueError("missing leading '---' frontmatter")
-              parts = txt[4:].split("\n---\n", 1)
-              if len(parts) != 2:
-                  raise ValueError("unterminated frontmatter (no closing '---')")
-              return yaml.safe_load(parts[0])
+              body = txt[4:]
+              # Closing '---' mid-file ('\n---\n') or at EOF with no trailing newline.
+              end = body.find("\n---\n")
+              if end == -1:
+                  if not body.endswith("\n---"):
+                      raise ValueError("unterminated frontmatter (no closing '---')")
+                  end = len(body) - 4
+              return yaml.safe_load(body[:end])
 
           files = sorted(
-              f for f in glob.glob(skills_glob)
+              f for f in glob.glob(skills_glob, recursive=True)
               if not os.path.basename(os.path.dirname(f)).startswith(("_", "."))
           )
           errors = []
+          # Treat zero matches as a misconfiguration, not a vacuous pass — a wrong
+          # working-directory/skills-glob must fail loudly, not silently disable the gate.
+          if not files:
+              errors.append(f"no SKILL.md matched '{skills_glob}' (after excluding _*/.* dirs) — check working-directory / skills-glob")
           for f in files:
               d = os.path.basename(os.path.dirname(f))
               try:

--- a/.github/workflows/test-skill-quality.yml
+++ b/.github/workflows/test-skill-quality.yml
@@ -64,14 +64,41 @@ jobs:
       - name: Install validator dependencies
         run: pip install "jsonschema==4.25.1" "PyYAML==6.0.2"
 
-      - name: Assert validator fails on bad fixture
+      - name: Assert canonical validator fails on bad fixture
         run: |
           set +e
           python3 templates/skills/validate-skills.py --dir _test-fixtures/skills-bad
           rc=$?
           set -e
           if [ "$rc" -eq 0 ]; then
-            echo "::error::validator exited 0 on a known-bad fixture; it should have failed"
+            echo "::error::canonical validator exited 0 on a known-bad fixture; it should have failed"
             exit 1
           fi
-          echo "✓ validator correctly rejected the bad fixture (exit $rc)"
+          echo "✓ canonical validator correctly rejected the bad fixture (exit $rc)"
+
+      # The reusable inlines its own copy of the validator (it runs in the caller's
+      # checkout and cannot read this repo's validate-skills.py). call-skill-quality-valid
+      # only exercises that inlined copy on VALID input, so its reject path could rot
+      # undetected. Extract it and assert it also rejects the bad fixture — this is what
+      # keeps the two hand-synced copies from drifting on the failure path.
+      - name: Assert inlined validator (from the reusable) fails on bad fixture
+        env:
+          SKILLS_GLOB: "_test-fixtures/skills-bad/*/SKILL.md"
+        run: |
+          awk "f && /^[[:space:]]*PY[[:space:]]*\$/ {exit} f {print} /<<'PY'/ {f=1}" \
+            .github/workflows/skill-quality.yml \
+            | python3 -c "import sys, textwrap; sys.stdout.write(textwrap.dedent(sys.stdin.read()))" \
+            > /tmp/inlined-validator.py
+          if [ ! -s /tmp/inlined-validator.py ]; then
+            echo "::error::failed to extract the inlined validator from skill-quality.yml"
+            exit 1
+          fi
+          set +e
+          python3 /tmp/inlined-validator.py
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::inlined validator exited 0 on a known-bad fixture; the two copies have drifted"
+            exit 1
+          fi
+          echo "✓ inlined validator correctly rejected the bad fixture (exit $rc)"

--- a/.github/workflows/test-skill-quality.yml
+++ b/.github/workflows/test-skill-quality.yml
@@ -1,0 +1,77 @@
+name: "Test: skill-quality.yml"
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/skill-quality.yml"
+      - ".github/workflows/test-skill-quality.yml"
+      - "templates/skills/**"
+      - "_test-fixtures/skills-minimal/**"
+      - "_test-fixtures/skills-bad/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/skill-quality.yml"
+      - ".github/workflows/test-skill-quality.yml"
+      - "templates/skills/**"
+      - "_test-fixtures/skills-minimal/**"
+      - "_test-fixtures/skills-bad/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # Positive path: a well-formed skill (plus a `_template` that must be skipped)
+  # must pass the reusable workflow.
+  call-skill-quality-valid:
+    name: Call skill-quality (valid fixtures)
+    uses: ./.github/workflows/skill-quality.yml
+    permissions:
+      contents: read
+    with:
+      working-directory: _test-fixtures/skills-minimal
+
+  # Negative path: a deliberately-broken skill must make the validator exit 1.
+  # Run the canonical local script directly so we can assert the failure.
+  negative-test:
+    name: Validator rejects bad frontmatter
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install validator dependencies
+        run: pip install "jsonschema==4.25.1" "PyYAML==6.0.2"
+
+      - name: Assert validator fails on bad fixture
+        run: |
+          set +e
+          python3 templates/skills/validate-skills.py --dir _test-fixtures/skills-bad
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::validator exited 0 on a known-bad fixture; it should have failed"
+            exit 1
+          fi
+          echo "✓ validator correctly rejected the bad fixture (exit $rc)"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ _test-fixtures/**/*-*
 !_test-fixtures/ts-minimal/**
 !_test-fixtures/go-release/
 !_test-fixtures/go-release/**
+!_test-fixtures/skills-minimal/
+!_test-fixtures/skills-minimal/**
+!_test-fixtures/skills-bad/
+!_test-fixtures/skills-bad/**
 coverage.out
 
 # Node.js

--- a/_test-fixtures/skills-bad/comma-tools-skill/SKILL.md
+++ b/_test-fixtures/skills-bad/comma-tools-skill/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: comma-tools-skill
+description: Negative fixture — valid except that allowed-tools uses commas instead of spaces. The validator MUST reject this (exit 1). Used by the negative-test job in test-skill-quality.yml.
+allowed-tools: Read, Bash, Grep
+tags: [web]
+---
+
+# Bad Skill (comma allowed-tools)
+
+Deliberately invalid. Do not "fix" this fixture.

--- a/_test-fixtures/skills-minimal/_template/SKILL.md
+++ b/_test-fixtures/skills-minimal/_template/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: <gerund-kebab-name>
+description: Scaffold template — intentionally has a placeholder name that does NOT match its directory. The validator MUST skip `_`-prefixed dirs, so this file must not produce an error.
+allowed-tools: Read, Bash
+tags: [web]
+---
+
+# Template
+
+If the validator did not exclude `_*` directories, this fixture's placeholder
+`name` and comma `allowed-tools` would fail the positive self-test. Its presence
+proves the exclusion works.

--- a/_test-fixtures/skills-minimal/example-cloud-skill/SKILL.md
+++ b/_test-fixtures/skills-minimal/example-cloud-skill/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: example-cloud-skill
+description: Use when validating the skill-quality reusable workflow against a well-formed skill — exercises every supported frontmatter field (name matching the directory, a non-empty description under 1024 chars, license, compatibility, metadata with string values, space-separated allowed-tools, in-vocabulary tags, and related links).
+license: Proprietary
+compatibility: Designed for Claude Code and guard-core
+metadata:
+  author: praetorian
+  version: "1.0"
+allowed-tools: Read Bash Grep Glob WebFetch
+tags: [cloud]
+related:
+  - example-web-skill
+---
+
+# Example Cloud Skill
+
+This is a fixture used only by `test-skill-quality.yml` to confirm the validator
+accepts a fully-populated, spec-conformant `SKILL.md`. It has no real content.

--- a/templates/skills/README.md
+++ b/templates/skills/README.md
@@ -52,11 +52,15 @@ jobs:
 
 ## Local usage (pre-commit)
 
+Run from your skill repo root, pointing at the canonical script in a checkout
+of `public-workflows` (or copy it locally):
+
 ```bash
 pip install jsonschema PyYAML
-python3 validate-skills.py            # validate */SKILL.md in cwd
-python3 validate-skills.py --dir path/to/skills
-python3 validate-skills.py --tags web,cloud,cicd,llm,cred
+VALIDATOR=path/to/public-workflows/templates/skills/validate-skills.py
+python3 "$VALIDATOR"                       # validate */SKILL.md in cwd
+python3 "$VALIDATOR" --dir path/to/skills
+python3 "$VALIDATOR" --tags web,cloud,cicd,llm,cred
 ```
 
 `validate-skills.py` is the canonical implementation; the CI workflow inlines an

--- a/templates/skills/README.md
+++ b/templates/skills/README.md
@@ -1,0 +1,64 @@
+# Skill Quality
+
+Validate Agent Skill `SKILL.md` frontmatter against the
+[agentskills.io specification](https://agentskills.io/specification) plus the
+Praetorian extensions (`tags`, `related`).
+
+## Why
+
+A malformed frontmatter block does **not** error in guard-core's skill loader —
+`LoadSkillMetadata` returns `nil` on a parse failure, so the skill is silently
+dropped from the platform with no log. Prettier-only markdown CI does not parse
+frontmatter (`embeddedLanguageFormatting` is off), so this class of bug is
+otherwise invisible until someone notices a missing skill. The `skill-quality`
+reusable workflow makes invalid frontmatter a hard CI failure.
+
+## What it checks
+
+agentskills.io core:
+
+- `name` (required): ≤64 chars, `[a-z0-9-]`, no leading/trailing/double hyphen,
+  and **must equal the parent directory name**.
+- `description` (required): 1–1024 chars, non-empty.
+- `license`, `compatibility` (≤500), `metadata` (string values only),
+  `allowed-tools` (space-separated, not comma) — optional.
+
+Praetorian extensions:
+
+- `tags`: list from a controlled vocabulary (default `web,cloud,cicd,llm,cred`).
+- `related`: list of skill links.
+
+Unknown top-level keys are rejected (catches typos like `descriptoin:` / `tag:`).
+Directories starting with `_` or `.` (templates, dev-time `.local`/`.history`)
+are skipped.
+
+## CI usage
+
+Add `.github/workflows/skill-quality.yml` to a skill repo:
+
+```yaml
+name: Skill Quality
+on:
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
+permissions:
+  contents: read
+jobs:
+  validate:
+    uses: praetorian-inc/public-workflows/.github/workflows/skill-quality.yml@<SHA> # <tag>
+    permissions:
+      contents: read
+```
+
+## Local usage (pre-commit)
+
+```bash
+pip install jsonschema PyYAML
+python3 validate-skills.py            # validate */SKILL.md in cwd
+python3 validate-skills.py --dir path/to/skills
+python3 validate-skills.py --tags web,cloud,cicd,llm,cred
+```
+
+`validate-skills.py` is the canonical implementation; the CI workflow inlines an
+identical copy so the check is atomically versioned with its pinned `@SHA`. Keep
+the two in sync when changing validation rules.

--- a/templates/skills/validate-skills.py
+++ b/templates/skills/validate-skills.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Validate Agent Skill `SKILL.md` frontmatter.
+
+Checks each skill's YAML frontmatter against the agentskills.io specification
+(https://agentskills.io/specification) plus the Praetorian extensions `tags`
+(controlled vocabulary) and `related` (skill links), both of which guard-core's
+skill loader reads.
+
+This is the canonical, locally-runnable copy of the validator that the
+`skill-quality.yml` reusable workflow inlines for CI. Keep the two in sync.
+
+Usage:
+    python3 validate-skills.py                 # validate */SKILL.md in cwd
+    python3 validate-skills.py --dir path/to/skills
+    python3 validate-skills.py --glob '*/SKILL.md' --tags web,cloud,cicd,llm,cred
+
+Requires: jsonschema, PyYAML.
+Exit code: 0 if all skills valid, 1 otherwise.
+"""
+import argparse
+import glob
+import os
+import sys
+
+import yaml
+from jsonschema import Draft202012Validator
+
+DEFAULT_TAGS = ["web", "cloud", "cicd", "llm", "cred"]
+
+
+def build_validator(tag_vocab):
+    # agentskills.io core + Praetorian extensions. additionalProperties:false
+    # catches frontmatter key typos (e.g. `descriptoin:`, `tag:`).
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["name", "description"],
+        "properties": {
+            "name": {"type": "string", "maxLength": 64,
+                     "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"},
+            "description": {"type": "string", "minLength": 1, "maxLength": 1024},
+            "license": {"type": "string"},
+            "compatibility": {"type": "string", "maxLength": 500},
+            "metadata": {"type": "object", "additionalProperties": {"type": "string"}},
+            "allowed-tools": {"type": "string"},
+            "tags": {"type": "array", "minItems": 1, "items": {"enum": tag_vocab}},
+            "related": {"type": "array", "items": {"type": "string"}},
+        },
+    }
+    return Draft202012Validator(schema)
+
+
+def frontmatter(path):
+    txt = open(path, encoding="utf-8").read()
+    if not txt.startswith("---\n"):
+        raise ValueError("missing leading '---' frontmatter")
+    parts = txt[4:].split("\n---\n", 1)
+    if len(parts) != 2:
+        raise ValueError("unterminated frontmatter (no closing '---')")
+    return yaml.safe_load(parts[0])
+
+
+def validate(directory, skills_glob, tag_vocab):
+    validator = build_validator(tag_vocab)
+    pattern = os.path.join(directory, skills_glob)
+    files = sorted(
+        f for f in glob.glob(pattern)
+        if not os.path.basename(os.path.dirname(f)).startswith(("_", "."))
+    )
+    errors = []
+    for f in files:
+        d = os.path.basename(os.path.dirname(f))
+        try:
+            fm = frontmatter(f)
+        except Exception as e:  # noqa: BLE001 — surface any parse failure verbatim
+            errors.append(f"{f}: invalid frontmatter — {e}")
+            continue
+        if not isinstance(fm, dict):
+            errors.append(f"{f}: frontmatter is not a mapping")
+            continue
+        for err in sorted(validator.iter_errors(fm), key=lambda e: list(e.path)):
+            loc = ".".join(map(str, err.path)) or "(root)"
+            errors.append(f"{f}: [{loc}] {err.message}")
+        if isinstance(fm.get("name"), str) and fm["name"] != d:
+            errors.append(
+                f"{f}: name '{fm['name']}' must equal parent directory '{d}' (agentskills.io)")
+        at = fm.get("allowed-tools")
+        if isinstance(at, str) and "," in at:
+            errors.append(
+                f"{f}: allowed-tools must be space-separated, not comma — got '{at}'")
+    return files, errors
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dir", default=".", help="directory containing skill subdirectories")
+    ap.add_argument("--glob", default="*/SKILL.md", help="glob for each skill's SKILL.md")
+    ap.add_argument("--tags", default=",".join(DEFAULT_TAGS),
+                    help="comma-separated controlled vocabulary for `tags`")
+    args = ap.parse_args()
+    tag_vocab = [t.strip() for t in args.tags.split(",") if t.strip()]
+
+    files, errors = validate(args.dir, args.glob, tag_vocab)
+    print(f"Validated {len(files)} skill(s) matching '{args.glob}' "
+          f"(excluding _*/.* dirs)\n")
+    if errors:
+        print(f"❌ {len(errors)} problem(s):")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print("✓ all skills conform to agentskills.io core + Praetorian extensions")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/skills/validate-skills.py
+++ b/templates/skills/validate-skills.py
@@ -52,23 +52,38 @@ def build_validator(tag_vocab):
 
 
 def frontmatter(path):
-    txt = open(path, encoding="utf-8").read()
+    # utf-8-sig strips a leading BOM (some Windows editors prepend one); text
+    # mode already normalizes CRLF/CR via universal newlines.
+    with open(path, encoding="utf-8-sig") as fh:
+        txt = fh.read()
     if not txt.startswith("---\n"):
         raise ValueError("missing leading '---' frontmatter")
-    parts = txt[4:].split("\n---\n", 1)
-    if len(parts) != 2:
-        raise ValueError("unterminated frontmatter (no closing '---')")
-    return yaml.safe_load(parts[0])
+    body = txt[4:]
+    # Closing delimiter: a '---' line mid-file ('\n---\n') or at EOF with no
+    # trailing newline ('\n---').
+    end = body.find("\n---\n")
+    if end == -1:
+        if not body.endswith("\n---"):
+            raise ValueError("unterminated frontmatter (no closing '---')")
+        end = len(body) - 4
+    return yaml.safe_load(body[:end])
 
 
 def validate(directory, skills_glob, tag_vocab):
     validator = build_validator(tag_vocab)
     pattern = os.path.join(directory, skills_glob)
     files = sorted(
-        f for f in glob.glob(pattern)
+        f for f in glob.glob(pattern, recursive=True)
         if not os.path.basename(os.path.dirname(f)).startswith(("_", "."))
     )
     errors = []
+    if not files:
+        # A wrong --dir/--glob (or a repo whose layout drifted from the default)
+        # would otherwise report success vacuously and silently disable the gate.
+        errors.append(
+            f"no SKILL.md matched '{pattern}' (after excluding _*/.* dirs) — "
+            "check the working-directory / skills-glob")
+        return files, errors
     for f in files:
         d = os.path.basename(os.path.dirname(f))
         try:


### PR DESCRIPTION
## What

A new reusable workflow `skill-quality.yml` that validates Agent Skill `SKILL.md` frontmatter against the [agentskills.io specification](https://agentskills.io/specification) plus the Praetorian extensions `tags` (controlled vocabulary) and `related` — both consumed by guard-core's skill loader.

## Why

guard-core's skill loader **silently drops** any skill whose frontmatter fails to parse — `LoadSkillMetadata` does `return nil` on a parse error with no log (`backend/pkg/lib/agent/skill_loader.go`). Our markdown CI is prettier-only and runs with `embeddedLanguageFormatting: off`, so it does **not** parse frontmatter. That leaves this failure class completely uncaught until a human notices a skill missing from the platform.

A concrete recent instance: a `SKILL.md` whose unquoted `description:` contained `access: external` was invalid YAML (`mapping values are not allowed here`). It passed all CI and would have made the skill invisible to guard-core.

## What it checks

**agentskills.io core:**
- `name` (required): ≤64 chars, `[a-z0-9-]`, no leading/trailing/double hyphen, **== parent directory name**
- `description` (required): 1–1024 chars, non-empty
- `license` / `compatibility` (≤500) / `metadata` (string values only) / `allowed-tools` (space-separated, not comma) — optional

**Praetorian extensions:**
- `tags`: list from a controlled vocab (default `web,cloud,cicd,llm,cred`)
- `related`: list of skill links

Unknown top-level keys are rejected (catches typos like `descriptoin:` / `tag:`). Dirs starting with `_` or `.` (templates, dev-time `.local`/`.history`) are skipped.

## Design

- **Engine:** owned JSON Schema (`jsonschema`, pinned) + procedural checks the schema can't express (`name == dir`; `allowed-tools` comma detection). Chosen over a third-party strict validator so our documented `tags`/`related` extensions are first-class rather than rejected.
- Mirrors `markdown-quality.yml` exactly: preflight `SKILL.md` change-gate (compare API, `contents: read`, fail-open), pinned Harden-Runner (`8d3c67de…`), checkout (`de0fac2e…`), and setup-python (`a309ff8b…` v6.2.0).
- The validator is inlined in the workflow (atomically versioned with the `@SHA`) and shipped as a canonical local/pre-commit copy at `templates/skills/validate-skills.py`.

## Files

| File | Purpose |
|------|---------|
| `.github/workflows/skill-quality.yml` | the reusable workflow |
| `.github/workflows/test-skill-quality.yml` | self-test: positive (valid fixtures, `_template` skipped) + negative (bad fixture must exit 1) |
| `templates/skills/validate-skills.py` | canonical local validator |
| `templates/skills/README.md` | docs + caller snippet |
| `_test-fixtures/skills-{minimal,bad}/` | fixtures |

## Testing

Validated locally: positive fixtures pass (with `_template` excluded), negative fixture correctly fails (exit 1), both workflow YAMLs parse. Proven against the real guard-skills set — flags exactly the 17 comma `allowed-tools`, nothing else.

First consumer: guard-skills (caller + `allowed-tools` fix) in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)