### PR TITLE
skill-quality: enforce strict agentskills.io frontmatter

### DIFF
--- a/.github/workflows/skill-quality.yml
+++ b/.github/workflows/skill-quality.yml
@@ -1,7 +1,9 @@
 name: Skill Quality (Callable)
 # Reusable workflow that validates Agent Skill `SKILL.md` frontmatter against the
-# agentskills.io specification (https://agentskills.io/specification) plus the
-# Praetorian extensions (`tags`, `related`) that guard-core's skill loader reads.
+# agentskills.io specification (https://agentskills.io/specification). Tags and
+# related links live under the standard `metadata` block (string values);
+# `metadata.tags` is checked against a controlled vocabulary. guard-core's loader
+# reads tags/related from `metadata`.
 #
 # Why this exists: a malformed frontmatter block does NOT produce an error in
 # guard-core's loader — it is silently skipped (LoadSkillMetadata returns nil on
@@ -65,7 +67,7 @@ on:
         default: "6.0.2"
 
       tag-vocabulary:
-        description: "Comma-separated controlled vocabulary for the `tags` extension."
+        description: "Comma-separated controlled vocabulary for `metadata.tags` values."
         required: false
         type: string
         default: "web,cloud,cicd,llm,cred"
@@ -202,9 +204,10 @@ jobs:
           tag_vocab = [t.strip() for t in os.environ.get(
               "TAG_VOCABULARY", "web,cloud,cicd,llm,cred").split(",") if t.strip()]
 
-          # agentskills.io core (https://agentskills.io/specification) + Praetorian
-          # extensions `tags` and `related`. additionalProperties:false catches
-          # frontmatter key typos (e.g. `descriptoin:`, `tag:`).
+          # Strict agentskills.io core (https://agentskills.io/specification).
+          # additionalProperties:false catches frontmatter key typos (e.g.
+          # `descriptoin:`) AND rejects the legacy top-level `tags`/`related`
+          # keys — those belong under `metadata` (validated procedurally below).
           schema = {
               "$schema": "https://json-schema.org/draft/2020-12/schema",
               "type": "object",
@@ -218,11 +221,20 @@ jobs:
                   "compatibility": {"type": "string", "maxLength": 500},
                   "metadata": {"type": "object", "additionalProperties": {"type": "string"}},
                   "allowed-tools": {"type": "string"},
-                  "tags": {"type": "array", "minItems": 1, "items": {"enum": tag_vocab}},
-                  "related": {"type": "array", "items": {"type": "string"}},
               },
           }
           validator = Draft202012Validator(schema)
+
+          def metadata_tags(fm):
+              # metadata.tags is a comma-separated string per the agentskills.io
+              # metadata convention (values must be strings).
+              meta = fm.get("metadata")
+              if not isinstance(meta, dict):
+                  return []
+              raw = meta.get("tags")
+              if not isinstance(raw, str):
+                  return []
+              return [t.strip() for t in raw.split(",") if t.strip()]
 
           def frontmatter(path):
               # utf-8-sig strips a leading BOM; text mode normalizes CRLF/CR.
@@ -267,6 +279,9 @@ jobs:
               at = fm.get("allowed-tools")
               if isinstance(at, str) and "," in at:
                   errors.append(f"{f}: allowed-tools must be space-separated, not comma — got '{at}'")
+              for tag in metadata_tags(fm):
+                  if tag not in tag_vocab:
+                      errors.append(f"{f}: [metadata.tags] '{tag}' not in controlled vocabulary {tag_vocab}")
 
           summary = os.environ.get("GITHUB_STEP_SUMMARY")
           lines = [f"## Skill Quality\n\nValidated **{len(files)}** skill(s) matching `{skills_glob}` "
@@ -275,7 +290,7 @@ jobs:
               lines.append(f"\n❌ **{len(errors)} problem(s):**\n")
               lines += [f"- `{e}`" for e in errors]
           else:
-              lines.append("\n✅ All skills conform to the agentskills.io core schema + Praetorian extensions.")
+              lines.append("\n✅ All skills conform to the agentskills.io specification.")
           if summary:
               with open(summary, "a", encoding="utf-8") as fh:
                   fh.write("\n".join(lines) + "\n")

--- a/_test-fixtures/skills-bad/bad-metadata-tag-skill/SKILL.md
+++ b/_test-fixtures/skills-bad/bad-metadata-tag-skill/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: bad-metadata-tag-skill
+description: Negative fixture — valid except that metadata.tags contains a value outside the controlled vocabulary (web,cloud,cicd,llm,cred). The validator MUST reject this (exit 1). Do not "fix" this fixture.
+allowed-tools: Read Bash Grep
+metadata:
+  tags: "web,notavalidtag"
+---
+
+# Bad Skill (out-of-vocabulary metadata.tag)
+
+Deliberately invalid: `notavalidtag` is not in the controlled vocabulary. Do not
+"fix" this fixture.

--- a/_test-fixtures/skills-bad/comma-tools-skill/SKILL.md
+++ b/_test-fixtures/skills-bad/comma-tools-skill/SKILL.md
@@ -2,7 +2,8 @@
 name: comma-tools-skill
 description: Negative fixture — valid except that allowed-tools uses commas instead of spaces. The validator MUST reject this (exit 1). Used by the negative-test job in test-skill-quality.yml.
 allowed-tools: Read, Bash, Grep
-tags: [web]
+metadata:
+  tags: "web"
 ---
 
 # Bad Skill (comma allowed-tools)

--- a/_test-fixtures/skills-bad/legacy-toplevel-tags-skill/SKILL.md
+++ b/_test-fixtures/skills-bad/legacy-toplevel-tags-skill/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: legacy-toplevel-tags-skill
+description: Negative fixture — valid except it uses the legacy top-level `tags` key instead of `metadata.tags`. Strict agentskills.io rejects unknown top-level keys, so the validator MUST reject this (exit 1). Do not "fix" this fixture.
+allowed-tools: Read Bash Grep
+tags: [web]
+---
+
+# Bad Skill (legacy top-level tags)
+
+Deliberately invalid under the strict agentskills.io schema. Tags belong under
+`metadata` as a comma-separated string. Do not "fix" this fixture.

--- a/_test-fixtures/skills-minimal/example-cloud-skill/SKILL.md
+++ b/_test-fixtures/skills-minimal/example-cloud-skill/SKILL.md
@@ -1,15 +1,14 @@
 ---
 name: example-cloud-skill
-description: Use when validating the skill-quality reusable workflow against a well-formed skill — exercises every supported frontmatter field (name matching the directory, a non-empty description under 1024 chars, license, compatibility, metadata with string values, space-separated allowed-tools, in-vocabulary tags, and related links).
+description: Use when validating the skill-quality reusable workflow against a well-formed skill — exercises every supported frontmatter field (name matching the directory, a non-empty description under 1024 chars, license, compatibility, metadata with string values including in-vocabulary metadata.tags and related links, and space-separated allowed-tools).
 license: Proprietary
 compatibility: Designed for Claude Code and guard-core
 metadata:
   author: praetorian
   version: "1.0"
+  tags: "cloud"
+  related: "example-web-skill"
 allowed-tools: Read Bash Grep Glob WebFetch
-tags: [cloud]
-related:
-  - example-web-skill
 ---
 
 # Example Cloud Skill

--- a/templates/skills/validate-skills.py
+++ b/templates/skills/validate-skills.py
@@ -2,9 +2,10 @@
 """Validate Agent Skill `SKILL.md` frontmatter.
 
 Checks each skill's YAML frontmatter against the agentskills.io specification
-(https://agentskills.io/specification) plus the Praetorian extensions `tags`
-(controlled vocabulary) and `related` (skill links), both of which guard-core's
-skill loader reads.
+(https://agentskills.io/specification). Tags and related links live under the
+standard `metadata` block as comma-separated string values; `metadata.tags` is
+additionally checked against a controlled vocabulary. Top-level `tags`/`related`
+are rejected — guard-core's loader reads them from `metadata`.
 
 This is the canonical, locally-runnable copy of the validator that the
 `skill-quality.yml` reusable workflow inlines for CI. Keep the two in sync.
@@ -28,9 +29,11 @@ from jsonschema import Draft202012Validator
 DEFAULT_TAGS = ["web", "cloud", "cicd", "llm", "cred"]
 
 
-def build_validator(tag_vocab):
-    # agentskills.io core + Praetorian extensions. additionalProperties:false
-    # catches frontmatter key typos (e.g. `descriptoin:`, `tag:`).
+def build_validator():
+    # Strict agentskills.io core (https://agentskills.io/specification).
+    # additionalProperties:false catches frontmatter key typos (e.g.
+    # `descriptoin:`) AND now rejects the legacy top-level `tags`/`related`
+    # keys — those belong under `metadata` (validated procedurally below).
     schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -44,11 +47,20 @@ def build_validator(tag_vocab):
             "compatibility": {"type": "string", "maxLength": 500},
             "metadata": {"type": "object", "additionalProperties": {"type": "string"}},
             "allowed-tools": {"type": "string"},
-            "tags": {"type": "array", "minItems": 1, "items": {"enum": tag_vocab}},
-            "related": {"type": "array", "items": {"type": "string"}},
         },
     }
     return Draft202012Validator(schema)
+
+
+def metadata_tags(fm):
+    """Parse metadata.tags (comma-separated string) into a list of tags."""
+    meta = fm.get("metadata")
+    if not isinstance(meta, dict):
+        return []
+    raw = meta.get("tags")
+    if not isinstance(raw, str):
+        return []
+    return [t.strip() for t in raw.split(",") if t.strip()]
 
 
 def frontmatter(path):
@@ -70,7 +82,7 @@ def frontmatter(path):
 
 
 def validate(directory, skills_glob, tag_vocab):
-    validator = build_validator(tag_vocab)
+    validator = build_validator()
     pattern = os.path.join(directory, skills_glob)
     files = sorted(
         f for f in glob.glob(pattern, recursive=True)
@@ -104,6 +116,10 @@ def validate(directory, skills_glob, tag_vocab):
         if isinstance(at, str) and "," in at:
             errors.append(
                 f"{f}: allowed-tools must be space-separated, not comma — got '{at}'")
+        for tag in metadata_tags(fm):
+            if tag not in tag_vocab:
+                errors.append(
+                    f"{f}: [metadata.tags] '{tag}' not in controlled vocabulary {tag_vocab}")
     return files, errors
 
 
@@ -125,7 +141,7 @@ def main():
         for e in errors:
             print(f"  - {e}")
         return 1
-    print("✓ all skills conform to agentskills.io core + Praetorian extensions")
+    print("✓ all skills conform to the agentskills.io specification")
     return 0
 
 


### PR DESCRIPTION
## Summary
Makes the `skill-quality` validator enforce **strict agentskills.io**: legacy top-level `tags`/`related` are now rejected (they belong under the standard `metadata` block), and `metadata.tags` values are checked against the controlled vocabulary — so the typo guard is preserved without the non-standard top-level extension.

- Updated **both** copies in lockstep: `templates/skills/validate-skills.py` and the inlined validator in `.github/workflows/skill-quality.yml`.
- Fixtures: migrated positive (`example-cloud-skill`) + `comma-tools-skill` to `metadata.tags`; added two negatives — `legacy-toplevel-tags-skill` and `bad-metadata-tag-skill`.

## Verified locally
Positive fixtures pass; all 3 bad fixtures fail with correct isolated errors; the inlined copy (extracted as `test-skill-quality.yml` does) matches; strict validator passes guard-skills' migrated branch and rejects current top-level-tags content.

## Rollout (shared workflow)
Consumers pin by SHA, so nothing changes until a repo repins. guard-skills should repin **only after** its skills move to `metadata.tags`, else its main CI fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)