### PR TITLE
harden(ci): airtight workflows before reverting public-workflows to public

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,12 @@
 # Default owner — repo maintainer
 *                                           @nsportsman
 
+# Every reusable workflow propagates to 40+ caller repos. Any change to ANY
+# workflow file — not just the AI reviewers below — requires Security Engineering
+# review so a hardening regression (injection, over-permission, unpinned action,
+# pwn-request) can't land unreviewed. Specific reviewers below add finer rationale.
+/.github/workflows/                         @praetorian-inc/security-engineering @nsportsman
+
 # Claude-code.yml reviews content from PRs (including CLAUDE.md, PR bodies, comments)
 # through Claude with a hardcoded, non-configurable tool allowlist. Any change to the
 # allowlist, trigger gates, or Claude invocation requires Security Engineering review

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main]
 
+# Least-privilege default for the whole workflow; the single job below explicitly
+# elevates to contents: write only for itself (to push the tag).
 permissions:
-  contents: write
-  pull-requests: read
+  contents: read
 
 jobs:
   auto-tag:

--- a/.github/workflows/changelog-scan.yml
+++ b/.github/workflows/changelog-scan.yml
@@ -202,6 +202,7 @@ jobs:
           fi
 
       - name: Checkout caller repo
+        # zizmor: ignore[artipacked]  # credential persistence required: the state writeback git-pushes to the branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Full history: the state writeback does `git pull --rebase` against the branch, and a
@@ -210,7 +211,7 @@ jobs:
 
       - name: Mint GitHub App token (read the watch repos)
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0 # zizmor: ignore[github-app] token scoped to owner/repos inputs, bounded by App install
         with:
           app-id: ${{ secrets.app_id }}
           private-key: ${{ secrets.app_private_key }}

--- a/.github/workflows/go-auto-tag.yml
+++ b/.github/workflows/go-auto-tag.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Generate app token
         id: app-token
         if: ${{ env.VB_APP_ID != '' }}
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
         with:
           app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
           private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}
@@ -147,6 +147,7 @@ jobs:
           fetch-depth: 0
           # The app token (when configured) persists as the push credential, so the
           # tag push is authorized as the bypass-actor App. Falls back to GITHUB_TOKEN.
+          # zizmor: ignore[artipacked]  # credential persistence required: this job pushes the tag
           token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Fetch all tags

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -327,7 +327,12 @@ jobs:
 
       - name: Run tests
         working-directory: ${{ inputs.working-directory }}
-        run: go test ${{ inputs.test-flags }} ${{ inputs.test-packages }}
+        env:
+          TEST_FLAGS: ${{ inputs.test-flags }}
+          TEST_PACKAGES: ${{ inputs.test-packages }}
+        run: |
+          # shellcheck disable=SC2086  # intentional word-split: flags/packages are space-separated lists
+          go test $TEST_FLAGS $TEST_PACKAGES
 
       - name: Upload coverage
         if: ${{ inputs.upload-coverage && inputs.enable-test }}
@@ -371,11 +376,14 @@ jobs:
 
       - name: Determine binary name
         id: binary
+        env:
+          BUILD_BINARY_NAME: ${{ inputs.build-binary-name }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          if [ -n "${{ inputs.build-binary-name }}" ]; then
-            echo "name=${{ inputs.build-binary-name }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$BUILD_BINARY_NAME" ]; then
+            echo "name=$BUILD_BINARY_NAME" >> "$GITHUB_OUTPUT"
           else
-            echo "name=${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
+            echo "name=$REPO_NAME" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build
@@ -384,7 +392,9 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: ${{ inputs.build-cgo-enabled }}
+          BINARY_NAME: ${{ steps.binary.outputs.name }}
+          BUILD_CMD_PATH: ${{ inputs.build-cmd-path }}
         run: |
           go build -trimpath -ldflags="-s -w" \
-            -o "${{ steps.binary.outputs.name }}-${{ matrix.goos }}-${{ matrix.goarch }}" \
-            ${{ inputs.build-cmd-path }}
+            -o "${BINARY_NAME}-${GOOS}-${GOARCH}" \
+            "$BUILD_CMD_PATH"

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -252,7 +252,7 @@ jobs:
       - name: Generate app token
         id: app-token
         if: ${{ inputs.release-mode == 'auto-tag-from-main' && env.VB_APP_ID != '' }}
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
         with:
           app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
           private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}
@@ -263,6 +263,7 @@ jobs:
           fetch-depth: 0
           # App token (when configured) persists as the push credential so the
           # tag push is authorized as the bypass-actor App. Falls back to GITHUB_TOKEN.
+          # zizmor: ignore[artipacked]  # credential persistence is required: this job pushes the tag
           token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Fetch all tags
@@ -411,12 +412,18 @@ jobs:
         with:
           fetch-depth: 0
           ref: refs/tags/${{ needs.resolve-version.outputs.version }}
+          # GoReleaser publishes via GITHUB_TOKEN (env), not the git-persisted
+          # credential, so don't leave the token in .git/config for later steps.
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: ${{ inputs.working-directory }}/${{ inputs.go-version-file }}
-          cache: true
+          # cache disabled in the release job: a module cache is writable by less-
+          # privileged workflows on the same repo and could be poisoned into a
+          # release build. Release runs are infrequent, so the rebuild cost is cheap.
+          cache: false
 
       - name: Install Syft (SBOM generator)
         if: ${{ inputs.enable-sbom }}
@@ -487,6 +494,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Deletion uses GH_TOKEN (env) via the gh CLI, not the git credential.
+          persist-credentials: false
 
       - name: Delete release and tag
         env:

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -317,7 +317,9 @@ jobs:
           cache: false
 
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@${{ inputs.gosec-version }}
+        env:
+          GOSEC_VERSION: ${{ inputs.gosec-version }}
+        run: go install "github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}"
 
       - name: Run gosec
         working-directory: ${{ inputs.working-directory }}
@@ -407,7 +409,9 @@ jobs:
           cache: false
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@${{ inputs.govulncheck-version }}
+        env:
+          GOVULNCHECK_VERSION: ${{ inputs.govulncheck-version }}
+        run: go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
 
       # SARIF mode runs only when the result will actually be uploaded (public
       # repo, or private repo that opted in via force-upload-private). Otherwise
@@ -418,6 +422,7 @@ jobs:
         shell: bash
         env:
           FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
+          GOVULNCHECK_PACKAGE: ${{ inputs.govulncheck-package }}
         # govulncheck exits 0 on clean, 3 on vulns-found, other on error. Under
         # the default `bash -e` shell, exit 3 aborts the step mid-pipe and can
         # leave govulncheck-results.sarif empty or truncated; the subsequent
@@ -427,7 +432,8 @@ jobs:
         # minimal valid SARIF on malformed output so upload always succeeds.
         run: |
           set +e
-          govulncheck -format sarif ${{ inputs.govulncheck-package }} > govulncheck-results.sarif 2> govulncheck-stderr.log
+          # shellcheck disable=SC2086  # package spec may be a space-separated list (e.g. ./...)
+          govulncheck -format sarif $GOVULNCHECK_PACKAGE > govulncheck-results.sarif 2> govulncheck-stderr.log
           EXIT=$?
           echo "govulncheck exit code: $EXIT"
           if [ -s govulncheck-stderr.log ]; then
@@ -470,9 +476,11 @@ jobs:
         shell: bash
         env:
           FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
+          GOVULNCHECK_PACKAGE: ${{ inputs.govulncheck-package }}
         run: |
           set +e
-          govulncheck ${{ inputs.govulncheck-package }}
+          # shellcheck disable=SC2086  # package spec may be a space-separated list (e.g. ./...)
+          govulncheck $GOVULNCHECK_PACKAGE
           EXIT=$?
           echo "govulncheck exit code: $EXIT"
           # exit 3 = vulns found. Gate the build only when enforcing.

--- a/.github/workflows/review-claude.yml
+++ b/.github/workflows/review-claude.yml
@@ -10,11 +10,18 @@ concurrency:
   group: claude-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}  # stray review comments must not cancel an in-progress review
 
+# Least-privilege default; the job below scopes exactly what the reviewer needs.
+permissions:
+  contents: read
+
 jobs:
   claude-code-action:
     uses: ./.github/workflows/claude-code.yml
     permissions:
-      contents: write
+      # contents: read (not write) — the claude-code.yml reusable's jobs cap at
+      # contents: read; granting write here is excess the reviewer never uses, and
+      # it widens the blast radius of a prompt-injection on a same-repo PR.
+      contents: read
       pull-requests: write
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/review-codex.yml
+++ b/.github/workflows/review-codex.yml
@@ -10,6 +10,10 @@ concurrency:
   group: codex-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}  # stray review comments must not cancel an in-progress review
 
+# Least-privilege default; the job below scopes exactly what the reviewer needs.
+permissions:
+  contents: read
+
 jobs:
   codex-review:
     uses: ./.github/workflows/codex-code.yml

--- a/.github/workflows/review-gemini.yml
+++ b/.github/workflows/review-gemini.yml
@@ -10,6 +10,10 @@ concurrency:
   group: gemini-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}  # stray review comments must not cancel an in-progress review
 
+# Least-privilege default; the job below scopes exactly what the reviewer needs.
+permissions:
+  contents: read
+
 jobs:
   gemini-review:
     uses: ./.github/workflows/gemini-code.yml

--- a/.github/workflows/self-audit.yml
+++ b/.github/workflows/self-audit.yml
@@ -1,0 +1,65 @@
+name: Self-Audit
+
+# Dogfood: scan THIS repo's own reusable workflows on every PR. A new High-severity
+# zizmor finding (injection, pwn-request, over-permission, unpinned action, …) or an
+# actionlint error blocks the merge — so "public = safe" stays true over time rather
+# than being a one-time cleanup. See SECURITY.md for the threat model.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: self-audit-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: zizmor + actionlint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        env:
+          ZIZMOR_VERSION: "1.25.2"
+        run: pipx install "zizmor==${ZIZMOR_VERSION}"
+
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: "v1.7.7"
+        run: go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}"
+
+      # Full report for visibility (every severity) — does not fail the build.
+      - name: zizmor report (informational)
+        run: zizmor --persona=regular --format=plain .github/workflows/ || true
+
+      # Gate: any High-severity finding fails the merge. Accepted lower-severity
+      # findings and documented exceptions (# zizmor: ignore[...]) do not.
+      - name: zizmor gate (High blocks merge)
+        run: zizmor --persona=regular --min-severity=high --format=plain .github/workflows/
+
+      - name: actionlint
+        # shellcheck at warning+ severity: gate on real issues (injection, undefined
+        # vars, expression errors), not pre-existing style nits (SC2006 backticks, etc.).
+        run: actionlint -color -shellcheck="-S warning"

--- a/.github/workflows/test-go-release.yml
+++ b/.github/workflows/test-go-release.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install yamllint
         run: pip install --quiet yamllint
@@ -62,6 +64,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check SHA pins
         run: |
@@ -104,6 +108,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run version calculation tests
         run: bash _test-fixtures/go-release/test-version-calc.sh
@@ -123,6 +129,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
@@ -130,7 +138,8 @@ jobs:
           go-version-file: _test-fixtures/go-release/go.mod
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2
+        # install-only: just fetches the binary, no release/cache write
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2 # zizmor: ignore[cache-poisoning]
         with:
           install-only: true
           version: v2.13.3

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Generate token for private dependencies
         if: ${{ inputs.enable-private-deps }}
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by plugin-ci App install
         with:
           app-id: ${{ secrets.PLUGIN_CI_APP_ID }}
           private-key: ${{ secrets.PLUGIN_CI_PRIVATE_KEY }}
@@ -365,7 +365,7 @@ jobs:
       - name: Generate token for private dependencies
         if: ${{ inputs.enable-private-deps }}
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by plugin-ci App install
         with:
           app-id: ${{ secrets.PLUGIN_CI_APP_ID }}
           private-key: ${{ secrets.PLUGIN_CI_PRIVATE_KEY }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
         with:
           app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
           private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}
@@ -65,6 +65,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          # zizmor: ignore[artipacked]  # credential persistence required: this job commits + pushes the bump
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Determine bump level from merged PR

--- a/.github/workflows/version-set.yml
+++ b/.github/workflows/version-set.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
         with:
           app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
           private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}
@@ -77,6 +77,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          # zizmor: ignore[artipacked]  # credential persistence required: this job commits + pushes the version
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set version

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Why this repository is public
+
+`public-workflows` holds **reusable GitHub Actions workflows** that are called by both
+public and internal `praetorian-inc` repositories. GitHub only allows a **public**
+repository to call a reusable workflow that lives in another **public** repository — a
+public caller cannot reach a private/internal one. Because public repos (e.g. `titus`,
+`brutus`, `nerva`, `pius`, `hadrian`, `julius`, …) depend on these workflows, this
+repository **must** be public.
+
+Publishing CI configuration is safe **by design, not by obscurity**: the workflows here
+contain no secrets (only secret *names*, resolved at runtime by the caller), and they are
+hardened so that reading them reveals no exploitable path. Hiding insecure CI would not
+make it secure — it would only delay discovery. We instead keep the configuration correct
+and auditable.
+
+## Threat model & controls
+
+These workflows run untrusted PR content (AI reviewers) and hold push/release credentials
+(version + release automation). The controls that keep "public" safe:
+
+| Threat | Control |
+| --- | --- |
+| **Pwn request** (privileged trigger + untrusted checkout + secrets) | No workflow checks out PR `head`. AI reviewers trigger on `pull_request` (fork PRs get a read-only token and **no secrets**), never `pull_request_target`. Privileged automation (`changelog-scan`) allowlists `schedule`/`workflow_dispatch` only and refuses every other event. |
+| **Script injection** (`${{ github.event.* }}`/`inputs.*` into `run:`) | Untrusted/templated values are bound to `env:` and referenced as shell variables, never interpolated directly into `run:`. |
+| **Over-privileged token** | Default `permissions:` are least-privilege and job-scoped; `contents: write` is granted only to the specific jobs that push tags/commits/releases. |
+| **Credential leakage** (`artipacked`) | `persist-credentials: false` on every checkout that does not itself push. The few checkouts that *do* push use a scoped GitHub App token and are annotated `# zizmor: ignore[artipacked]` with rationale. |
+| **Supply chain** | Every `uses:` is pinned to a full 40-char commit SHA (enforced by `verify-pins.yml` and the self-audit gate). |
+| **Cache poisoning** | Caching is disabled in release jobs (an immutable-tag build must not consume a cache writable by a less-privileged workflow). |
+| **Egress / exfiltration** | Sensitive jobs run `step-security/harden-runner` with `disable-sudo-and-containers` and, for the highest-privilege job, `egress-policy: block` with a host allowlist. |
+
+## Self-enforcement
+
+Every PR to this repo runs `self-audit.yml`: **zizmor** (workflow security scanner) +
+**actionlint**. A new High-severity finding blocks the merge. `.github/CODEOWNERS`
+additionally requires Security Engineering review on any change under
+`.github/workflows/`.
+
+## Reporting a vulnerability
+
+Email **security@praetorian.com** with details. Please do not open a public issue for
+suspected vulnerabilities in these workflows.


### PR DESCRIPTION
## Why

`public-workflows` was flipped to **internal** during an incident response, which broke CI for **11 public repos** that call its reusable workflows (augustus, aurelian, brutus, capability-sdk, hadrian, julius, nerva, pius, titus, trajan, vespasian). GitHub forbids a public repo from calling a reusable workflow in an internal/private repo — so the only fix is to **revert this repo to public**.

A full-history secret scan (titus, all refs) confirmed **zero secrets** were ever committed here. The risk was never secrets — it's whether the CI config reveals an exploitable attack path. This PR closes that gap so **public = safe by design, not obscurity**, then the visibility flip can happen.

## Result

`zizmor --persona=auditor` (strictest) across all 30 workflow files: **0 High / 0 Medium** (down from 20 High / 16 Medium). Only Low/Informational hygiene remains. `actionlint` clean at warning+ severity. The single most dangerous pattern — privileged trigger + untrusted PR-head checkout — was already absent (reviewers run on `pull_request`, not `pull_request_target`).

## Genuine fixes

- **`review-claude.yml`**: `contents: write` → `read` — the reusable's jobs cap at `read`; this removes the only reviewer that could push on a same-repo prompt-injection.
- **`auto-tag.yml` + the 3 reviewers**: explicit least-privilege top-level `permissions: contents: read` (was absent/over-broad).
- **`go-ci.yml`, `go-sec.yml`**: `env:`-indirection for every `inputs.*` interpolated into `run:` (script-injection hardening; no behavior change — arg word-splitting preserved with `shellcheck disable=SC2086`).
- **`go-release.yml`**: `persist-credentials: false` on the non-pushing build + cleanup checkouts; `cache: false` in the release job (an immutable-tag build must not consume a cache a less-privileged workflow can poison).
- **`test-go-release.yml`**: `persist-credentials: false` on all (read-only) test checkouts.

## Documented exceptions (`# zizmor: ignore[...]` + rationale)

- Checkouts that **must** persist a credential because the job pushes (version-bump, version-set, go-auto-tag, go-release resolve, changelog-scan state-writeback).
- `create-github-app-token` usage — the minted token is bounded by the App's **installation** permissions (the real least-privilege ceiling, which zizmor can't introspect).
- `goreleaser` `install-only` step (no release/cache write).

## Durability (keeps it airtight over time)

- **`self-audit.yml`**: dogfoods zizmor + actionlint on every PR; a new High-severity finding **blocks the merge**.
- **`CODEOWNERS`**: Security Engineering review now required on **all** `.github/workflows/` changes (was only the 3 AI reviewers).
- **`SECURITY.md`**: documents why the repo is public + the full threat model and controls.

## After merge

Flip visibility back to public (`gh repo edit praetorian-inc/public-workflows --visibility public`), leaving `access_level=organization` as-is. That unbreaks the 11 public callers; internal callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)