### PR TITLE
fix(reviewers): token-gate palatine curated-skills checkout, fail-closed

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -139,6 +139,10 @@ jobs:
     # (a step `if:` cannot read `secrets.*` directly).
     env:
       PALATINE_APP_ID: ${{ secrets.PALATINE_SKILLS_APP_ID }}
+      # Presence-only boolean (NOT the key itself) so the mint step can require BOTH
+      # creds in `if:` — a caller passing the App ID without the PEM then degrades to
+      # "run without curated skills" instead of hard-failing the job at token minting.
+      PALATINE_KEY_SET: ${{ secrets.PALATINE_SKILLS_PRIVATE_KEY != '' }}
 
     steps:
       - name: Harden Runner
@@ -239,7 +243,7 @@ jobs:
       # either way. Pinned to a commit SHA — callers cannot point this elsewhere.
       - name: Mint palatine read token
         id: skills-token
-        if: ${{ env.PALATINE_APP_ID != '' }}
+        if: ${{ env.PALATINE_APP_ID != '' && env.PALATINE_KEY_SET == 'true' }}
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scoped to palatine read via owner/repositories inputs, bounded by App install
         with:
           app-id: ${{ secrets.PALATINE_SKILLS_APP_ID }}

--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -70,6 +70,12 @@ on:
       OPENAI_API_KEY:
         description: "OpenAI API key for Codex (pay-per-token billing)"
         required: true
+      PALATINE_SKILLS_APP_ID:
+        description: "GitHub App ID (client ID) for an App with contents:read on praetorian-inc/palatine. OPTIONAL: when set (trusted internal callers), the curated review skills are loaded; when unset (public repos / fork PRs), the review runs without them (fail-closed — internal skills never enter a public run's logs)."
+        required: false
+      PALATINE_SKILLS_PRIVATE_KEY:
+        description: "Private key (PEM) for the App in PALATINE_SKILLS_APP_ID. Required only when PALATINE_SKILLS_APP_ID is set."
+        required: false
 
 permissions:
   contents: read
@@ -128,6 +134,11 @@ jobs:
 
     outputs:
       final_message: ${{ steps.run_codex.outputs.final-message }}
+
+    # Mapped from the secret so the optional palatine-token step can be gated in `if:`
+    # (a step `if:` cannot read `secrets.*` directly).
+    env:
+      PALATINE_APP_ID: ${{ secrets.PALATINE_SKILLS_APP_ID }}
 
     steps:
       - name: Harden Runner
@@ -218,19 +229,38 @@ jobs:
 
       # Curated review skills, auto-discovered by the Codex CLI from `.agents/skills`
       # in the CWD (implicit, task-matched invocation — developers.openai.com/codex/skills).
-      # praetorian-inc/palatine is the canonical source-of-truth repo. Pinned to a
-      # commit SHA — callers cannot point this elsewhere. Public repo => no token.
+      # praetorian-inc/palatine is the canonical source-of-truth repo and is INTERNAL,
+      # so reading it requires a token. We mint a short-lived GitHub App token scoped to
+      # palatine ONLY when the caller supplies the App credentials — i.e. on trusted
+      # internal callers. On public repos / fork PRs no such secret is available, so the
+      # mint + checkout + stage below are skipped and the review runs without curated
+      # skills (fail-closed: internal skills are never pulled into a public run's logs).
+      # The purge step above ALWAYS runs, so PR-supplied agent config is neutralized
+      # either way. Pinned to a commit SHA — callers cannot point this elsewhere.
+      - name: Mint palatine read token
+        id: skills-token
+        if: ${{ env.PALATINE_APP_ID != '' }}
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scoped to palatine read via owner/repositories inputs, bounded by App install
+        with:
+          app-id: ${{ secrets.PALATINE_SKILLS_APP_ID }}
+          private-key: ${{ secrets.PALATINE_SKILLS_PRIVATE_KEY }}
+          owner: praetorian-inc
+          repositories: palatine
+
       # Staged AFTER the purge so the sweep above never touches this trusted tree.
       - name: Load curated review skills (palatine)
+        if: ${{ steps.skills-token.outputs.token != '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: praetorian-inc/palatine
           ref: 1ad13aa73fc06b92676944ed74625d8c79b2b455  # palatine @ initial curated set
           path: .pr-skills
           fetch-depth: 1
+          token: ${{ steps.skills-token.outputs.token }}
           persist-credentials: false
 
       - name: Stage curated skills
+        if: ${{ steps.skills-token.outputs.token != '' }}
         run: |
           set -euo pipefail
           mkdir -p .agents/skills

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -92,6 +92,12 @@ on:
       GEMINI_API_KEY:
         description: "Google AI Studio API key for Gemini"
         required: true
+      PALATINE_SKILLS_APP_ID:
+        description: "GitHub App ID (client ID) for an App with contents:read on praetorian-inc/palatine. OPTIONAL: when set (trusted internal callers), the curated review skills are loaded; when unset (public repos / fork PRs), the review runs without them (fail-closed — internal skills never enter a public run's logs)."
+        required: false
+      PALATINE_SKILLS_PRIVATE_KEY:
+        description: "Private key (PEM) for the App in PALATINE_SKILLS_APP_ID. Required only when PALATINE_SKILLS_APP_ID is set."
+        required: false
 
 permissions:
   contents: read
@@ -149,6 +155,11 @@ jobs:
     outputs:
       review_output: ${{ steps.sanitize.outputs.review }}
 
+    # Mapped from the secret so the optional palatine-token step can be gated in `if:`
+    # (a step `if:` cannot read `secrets.*` directly).
+    env:
+      PALATINE_APP_ID: ${{ secrets.PALATINE_SKILLS_APP_ID }}
+
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable-harden-runner }}
@@ -177,18 +188,36 @@ jobs:
 
       # Curated review skills, loaded natively by Gemini CLI from `.gemini/skills/`.
       # praetorian-inc/palatine is the canonical-source-of-truth repo (agentmesh
-      # materializes one canonical skill set into each runtime's native dir). Pinned to
-      # a commit SHA — callers cannot point this elsewhere. Public repo => no token.
+      # materializes one canonical skill set into each runtime's native dir) and is
+      # INTERNAL, so reading it requires a token. We mint a short-lived GitHub App token
+      # scoped to palatine ONLY when the caller supplies the App credentials — i.e. on
+      # trusted internal callers. On public repos / fork PRs no such secret is available,
+      # so the mint + checkout + stage are skipped and the review runs without curated
+      # skills (fail-closed: internal skills are never pulled into a public run's logs).
+      # The purge step below ALWAYS runs, so PR-supplied agent config is neutralized
+      # either way. Pinned to a commit SHA — callers cannot point this elsewhere.
+      - name: Mint palatine read token
+        id: skills-token
+        if: ${{ env.PALATINE_APP_ID != '' }}
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scoped to palatine read via owner/repositories inputs, bounded by App install
+        with:
+          app-id: ${{ secrets.PALATINE_SKILLS_APP_ID }}
+          private-key: ${{ secrets.PALATINE_SKILLS_PRIVATE_KEY }}
+          owner: praetorian-inc
+          repositories: palatine
+
       - name: Load curated review skills (palatine)
+        if: ${{ steps.skills-token.outputs.token != '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: praetorian-inc/palatine
           ref: 1ad13aa73fc06b92676944ed74625d8c79b2b455  # palatine @ initial curated set
           path: .pr-skills
           fetch-depth: 1
+          token: ${{ steps.skills-token.outputs.token }}
           persist-credentials: false
 
-      - name: Purge PR-supplied agent config, then stage curated skills
+      - name: Purge PR-supplied agent config
         run: |
           set -euo pipefail
           # The merged tree is untrusted PR content, and workspace trust is enabled
@@ -221,6 +250,14 @@ jobs:
           find . \( -name .git -o -path ./.pr-skills \) -prune -o \
             \( -iname '.gemini' -o -iname '.agents' -o -iname 'GEMINI.md' -o -iname 'AGENTS.md' -o -iname '.geminiignore' \) \
             -prune -exec rm -rf {} +
+
+      # Stage the trusted curated tree AFTER the purge (which prunes .pr-skills) so the
+      # sweep never touches it. Gated on the token: skipped when no curated skills were
+      # checked out (public repos / fork PRs) — Gemini then reviews with no skills dir.
+      - name: Stage curated skills
+        if: ${{ steps.skills-token.outputs.token != '' }}
+        run: |
+          set -euo pipefail
           mkdir -p .gemini/skills
           cp -R .pr-skills/.gemini/skills/. .gemini/skills/
           rm -rf .pr-skills

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -119,12 +119,15 @@ jobs:
 
   # Gemini review: run the Gemini CLI as a read-only agent via run-gemini-cli.
   #
-  # The job has `contents: read` only — no PR write access — and NO step in it
-  # uses a GitHub token at all: the depth-2 merge-ref checkout brings the diff's
-  # parents locally, so "Build review context" computes the diff fully offline.
-  # This means even if the agent is compromised by prompt injection it has no
-  # credential to exfiltrate and no path to write to the PR. The post-feedback
-  # job posts.
+  # The job has `contents: read` only — no PR write access. The only credential it
+  # can hold is a short-lived GitHub App token, minted ONLY when a trusted caller
+  # supplies the palatine App creds, scoped to palatine read, and consumed solely by
+  # the curated-skills checkout (persist-credentials: false, so it is never written to
+  # .git/config). The Gemini agent step runs later and is never handed that token, and
+  # the depth-2 merge-ref checkout brings the diff's parents locally so "Build review
+  # context" computes the diff fully offline. So even if the agent is compromised by
+  # prompt injection it has no credential to exfiltrate and no path to write to the PR.
+  # The post-feedback job posts.
   gemini-review:
     needs: preflight
     if: |
@@ -159,6 +162,10 @@ jobs:
     # (a step `if:` cannot read `secrets.*` directly).
     env:
       PALATINE_APP_ID: ${{ secrets.PALATINE_SKILLS_APP_ID }}
+      # Presence-only boolean (NOT the key itself) so the mint step can require BOTH
+      # creds in `if:` — a caller passing the App ID without the PEM then degrades to
+      # "run without curated skills" instead of hard-failing the job at token minting.
+      PALATINE_KEY_SET: ${{ secrets.PALATINE_SKILLS_PRIVATE_KEY != '' }}
 
     steps:
       - name: Harden Runner
@@ -232,11 +239,11 @@ jobs:
       # trusted internal callers. On public repos / fork PRs no such secret is available,
       # so the mint + checkout + stage are skipped and the review runs without curated
       # skills (fail-closed: internal skills are never pulled into a public run's logs).
-      # The purge step below ALWAYS runs, so PR-supplied agent config is neutralized
+      # The purge step above ALWAYS runs, so PR-supplied agent config is neutralized
       # either way. Pinned to a commit SHA — callers cannot point this elsewhere.
       - name: Mint palatine read token
         id: skills-token
-        if: ${{ env.PALATINE_APP_ID != '' }}
+        if: ${{ env.PALATINE_APP_ID != '' && env.PALATINE_KEY_SET == 'true' }}
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scoped to palatine read via owner/repositories inputs, bounded by App install
         with:
           app-id: ${{ secrets.PALATINE_SKILLS_APP_ID }}

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -186,6 +186,44 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
 
+      # Neutralize PR-supplied agent config BEFORE anything trusted is staged. The merged
+      # tree is untrusted PR content and workspace trust is enabled (see
+      # GEMINI_CLI_TRUST_WORKSPACE below), so gemini-cli would honor any agent-control
+      # files it finds. Purge ALL of them so a same-repo PR cannot steer or blind the
+      # review:
+      #   - .gemini / .agents : skill + settings discovery dirs. `.agents/skills` takes
+      #     PRECEDENCE over `.gemini/skills`, so a PR-authored skill would load as a
+      #     "trusted" skill and drive the review via activate_skill.
+      #   - GEMINI.md / AGENTS.md (recursive): hierarchical agent instructions, loaded
+      #     from subdirectories too — root-only removal is insufficient, and gemini-cli
+      #     honors the AGENTS.md legacy name as well.
+      #   - .geminiignore (recursive): would silently blind glob/list_directory.
+      #   - .npmrc/.yarnrc* : run-gemini-cli installs the CLI with npm from this cwd; a
+      #     PR-supplied registry override is a supply-chain vector.
+      # This runs BEFORE the palatine checkout (which lands in .pr-skills), so the sweep
+      # is UNCONDITIONAL — there is NO .pr-skills carve-out. A PR shipping its own
+      # .pr-skills/GEMINI.md is therefore purged too; and if the gated checkout is skipped
+      # (no token: public repos / fork PRs) nothing trusted is staged and Gemini reviews
+      # with no agent config at all — never the attacker's. Settings + skills then come
+      # ONLY from the action input and, when present, the SHA-pinned palatine checkout.
+      # find flags:
+      #   - no -type f, so a *symlinked* GEMINI.md/AGENTS.md is removed (not skipped);
+      #     gemini-cli would otherwise resolve the link. -iname covers case variants.
+      #   - -prune on matches so find does NOT descend into a matched directory: with
+      #     -exec rm -rf {} + an ARG_MAX flush could otherwise delete a parent dir
+      #     mid-traversal and crash find under set -e.
+      #   - -exec rm -rf {} + (not -delete) removes files, symlinks AND directories
+      #     uniformly, so a dir named GEMINI.md can't break the sweep.
+      #   - skip .git (speed).
+      # .npmrc/.yarnrc* are root-only supply-chain files, removed directly.
+      - name: Purge PR-supplied agent config
+        run: |
+          set -euo pipefail
+          rm -rf .npmrc .yarnrc .yarnrc.yml
+          find . -name .git -prune -o \
+            \( -iname '.gemini' -o -iname '.agents' -o -iname 'GEMINI.md' -o -iname 'AGENTS.md' -o -iname '.geminiignore' \) \
+            -prune -exec rm -rf {} +
+
       # Curated review skills, loaded natively by Gemini CLI from `.gemini/skills/`.
       # praetorian-inc/palatine is the canonical-source-of-truth repo (agentmesh
       # materializes one canonical skill set into each runtime's native dir) and is
@@ -217,43 +255,10 @@ jobs:
           token: ${{ steps.skills-token.outputs.token }}
           persist-credentials: false
 
-      - name: Purge PR-supplied agent config
-        run: |
-          set -euo pipefail
-          # The merged tree is untrusted PR content, and workspace trust is enabled
-          # (see GEMINI_CLI_TRUST_WORKSPACE below) so gemini-cli would honor any
-          # agent-control files it finds. Purge ALL of them before staging ours so a
-          # same-repo PR cannot steer or blind the review:
-          #   - .gemini / .agents : skill + settings discovery dirs. `.agents/skills`
-          #     takes PRECEDENCE over `.gemini/skills`, so a PR-authored skill would
-          #     load as a "trusted" skill and drive the review via activate_skill.
-          #   - GEMINI.md / AGENTS.md (recursive): hierarchical agent instructions,
-          #     loaded from subdirectories too — root-only removal is insufficient,
-          #     and gemini-cli honors the AGENTS.md legacy name as well.
-          #   - .geminiignore (recursive): would silently blind glob/list_directory.
-          #   - .npmrc/.yarnrc* : run-gemini-cli installs the CLI with npm from this
-          #     cwd; a PR-supplied registry override is a supply-chain vector.
-          # The agent's settings + skills then come ONLY from the action input and the
-          # SHA-pinned palatine checkout.
-          # One robust recursive sweep for the discovery dirs (.gemini/.agents) and the
-          # instruction/ignore files (GEMINI.md/AGENTS.md/.geminiignore). find flags:
-          #   - no -type f, so a *symlinked* GEMINI.md/AGENTS.md is removed (not skipped);
-          #     gemini-cli would otherwise resolve the link. -iname covers case variants.
-          #   - -prune on matches so find does NOT descend into a matched directory: with
-          #     -exec rm -rf {} + an ARG_MAX flush could otherwise delete a parent dir
-          #     mid-traversal and crash find under set -e.
-          #   - -exec rm -rf {} + (not -delete) removes files, symlinks AND directories
-          #     uniformly, so a dir named GEMINI.md can't break the sweep.
-          #   - skip .git (speed) and .pr-skills (the trusted curated tree, staged below).
-          # .npmrc/.yarnrc* are root-only supply-chain files, removed directly.
-          rm -rf .npmrc .yarnrc .yarnrc.yml
-          find . \( -name .git -o -path ./.pr-skills \) -prune -o \
-            \( -iname '.gemini' -o -iname '.agents' -o -iname 'GEMINI.md' -o -iname 'AGENTS.md' -o -iname '.geminiignore' \) \
-            -prune -exec rm -rf {} +
-
-      # Stage the trusted curated tree AFTER the purge (which prunes .pr-skills) so the
-      # sweep never touches it. Gated on the token: skipped when no curated skills were
-      # checked out (public repos / fork PRs) — Gemini then reviews with no skills dir.
+      # Stage the trusted curated tree after the SHA-pinned palatine checkout. Gated on
+      # the token: skipped when no curated skills were checked out (public repos / fork
+      # PRs) — Gemini then reviews with no skills dir (PR-supplied config already purged
+      # unconditionally by the step above).
       - name: Stage curated skills
         if: ${{ steps.skills-token.outputs.token != '' }}
         run: |

--- a/.github/workflows/self-audit.yml
+++ b/.github/workflows/self-audit.yml
@@ -48,7 +48,12 @@ jobs:
       - name: Install actionlint
         env:
           ACTIONLINT_VERSION: "v1.7.7"
-        run: go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}"
+        # `go install` drops the binary in $(go env GOPATH)/bin, which is NOT on the
+        # runner's PATH (no setup-go here) — so a later bare `actionlint` would exit 127
+        # "command not found". Append that bin dir to GITHUB_PATH so the gate step finds it.
+        run: |
+          go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       # Full report for visibility (every severity) — does not fail the build.
       - name: zizmor report (informational)


### PR DESCRIPTION
## Problem

`palatine` (formerly `public-skills`) was flipped **INTERNAL** during the visibility incident (see PR #114). But the codex/gemini reviewers' curated-skills checkout still assumed palatine was **public** — comment literally read `Public repo => no token` and passed no `token:`.

The default `GITHUB_TOKEN` is scoped to the *running* repo only and **cannot read a different internal repo**. So on `main` today the **`Load curated review skills (palatine)` step fails on every caller** (internal callers too), breaking the codex and gemini reviewers' skill-load step org-wide.

(claude-code.yml is unaffected — it never checked out palatine.)

## Why palatine does NOT need to be public

A reusable-workflow **call** (`uses: org/repo/.github/workflows/x@sha`) public→internal is a *hard platform block*. But `actions/checkout` of an internal repo is just a **token** problem — solvable without exposing palatine. palatine stays internal permanently.

## Fix (mirrors the existing `go-auto-tag.yml` optional-app-token pattern)

- Add **optional** `PALATINE_SKILLS_APP_ID` / `PALATINE_SKILLS_PRIVATE_KEY` secrets (`required: false` → **non-breaking**).
- Mint a short-lived GitHub App token **scoped to palatine read** (`owner` + `repositories` inputs) **only when** the caller supplies the App credentials (trusted internal callers).
- **Gate** the palatine checkout + staging on the minted token. **Fail-closed**: no token (public repos / fork PRs) → steps skip → review runs without curated skills. Internal skills are never pulled into a public run's logs — that's the desired boundary, not a regression.
- The security **purge** of PR-supplied agent config **always runs** regardless (gemini's combined purge+stage step is split so the purge stays unconditional).

## Net effect of merging this alone

Even with **no** App/secret setup, the reviewers **stop failing** on the palatine checkout — they degrade gracefully to a generic review.

## Follow-up to restore curated skills on internal callers (operational, not required for this fix)

1. Create/identify a GitHub App with **contents: read** on `praetorian-inc/palatine`; install it on palatine.
2. Add org secrets `PALATINE_SKILLS_APP_ID` + `PALATINE_SKILLS_PRIVATE_KEY` (visibility = selected internal callers).
3. Have those internal callers pass the two secrets through to the `codex-code.yml` / `gemini-code.yml` reusables.

public-workflows' own caller wrappers (`review-codex.yml` / `review-gemini.yml`) are intentionally **left unchanged** — public-workflows is public, so its own reviewers correctly run fail-closed (generic review).

## Validation

- `zizmor --persona=auditor`: **0 high / 0 medium** (only pre-existing low `undocumented-permissions` on untouched `pull-requests: write` lines).
- `actionlint -shellcheck="-S warning"`: clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)