### PR TITLE
ci: bump create-github-app-token v1.12.0 → v3.2.0 (Node 20 → Node 24)

### DIFF
--- a/.github/workflows/changelog-scan.yml
+++ b/.github/workflows/changelog-scan.yml
@@ -287,7 +287,7 @@ jobs:
 
       - name: Mint GitHub App token (read the watch repos)
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0 # zizmor: ignore[github-app] token scoped to owner/repos inputs, bounded by App install
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0 # zizmor: ignore[github-app] token scoped to owner/repos inputs, bounded by App install
         with:
           app-id: ${{ secrets.app_id }}
           private-key: ${{ secrets.app_private_key }}

--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Mint palatine read token
         id: skills-token
         if: ${{ env.PALATINE_APP_ID != '' && env.PALATINE_KEY_SET == 'true' }}
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scoped to palatine read via owner/repositories inputs, bounded by App install
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0 # zizmor: ignore[github-app] token scoped to palatine read via owner/repositories inputs, bounded by App install
         with:
           app-id: ${{ secrets.PALATINE_SKILLS_APP_ID }}
           private-key: ${{ secrets.PALATINE_SKILLS_PRIVATE_KEY }}

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Mint palatine read token
         id: skills-token
         if: ${{ env.PALATINE_APP_ID != '' && env.PALATINE_KEY_SET == 'true' }}
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scoped to palatine read via owner/repositories inputs, bounded by App install
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0 # zizmor: ignore[github-app] token scoped to palatine read via owner/repositories inputs, bounded by App install
         with:
           app-id: ${{ secrets.PALATINE_SKILLS_APP_ID }}
           private-key: ${{ secrets.PALATINE_SKILLS_PRIVATE_KEY }}

--- a/.github/workflows/go-auto-tag.yml
+++ b/.github/workflows/go-auto-tag.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Generate app token
         id: app-token
         if: ${{ env.VB_APP_ID != '' }}
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
         with:
           app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
           private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -252,7 +252,7 @@ jobs:
       - name: Generate app token
         id: app-token
         if: ${{ inputs.release-mode == 'auto-tag-from-main' && env.VB_APP_ID != '' }}
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
         with:
           app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
           private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Generate token for private dependencies
         if: ${{ inputs.enable-private-deps }}
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by plugin-ci App install
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0 # zizmor: ignore[github-app] token scope bounded by plugin-ci App install
         with:
           app-id: ${{ secrets.PLUGIN_CI_APP_ID }}
           private-key: ${{ secrets.PLUGIN_CI_PRIVATE_KEY }}
@@ -365,7 +365,7 @@ jobs:
       - name: Generate token for private dependencies
         if: ${{ inputs.enable-private-deps }}
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by plugin-ci App install
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0 # zizmor: ignore[github-app] token scope bounded by plugin-ci App install
         with:
           app-id: ${{ secrets.PLUGIN_CI_APP_ID }}
           private-key: ${{ secrets.PLUGIN_CI_PRIVATE_KEY }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
         with:
           app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
           private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}

--- a/.github/workflows/version-set.yml
+++ b/.github/workflows/version-set.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0 # zizmor: ignore[github-app] token scope bounded by praetorian-ci App install
         with:
           app-id: ${{ secrets.VERSION_BUMPER_APP_ID }}
           private-key: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}


### PR DESCRIPTION
## What

Bumps `actions/create-github-app-token` from `v1.12.0` (`d72941d`) to **`v3.2.0`** (`bcd2ba49218906704ab6c1aa796996da409d3eb1`) across all **9** usages in the reusable workflows:

| File | App install |
|------|-------------|
| `changelog-scan.yml` | featurebase-changelog-bot |
| `go-auto-tag.yml`, `go-release.yml`, `version-bump.yml`, `version-set.yml` | praetorian-ci |
| `codex-code.yml`, `gemini-code.yml` | palatine |
| `ts-ci.yml` (×2) | plugin-ci |

## Why

`v1.12.0` runs on **Node 20**, which GitHub:
- forced to Node 24 by default on **2026-06-16** (now emitting a deprecation warning on every run), and
- **removes from the runner on 2026-09-16**.

`v3.2.0` is the latest release (2026-05-12) and runs on Node 24. It is already in production use in `praetorian-inc/guard-documentation` (PR #104), so this just brings the central reusables in line.

## Risk

Pure pin bump — no inputs, behavior, or token scope change. The per-call `owner`/`repositories` App-install boundaries and the `zizmor: ignore[github-app]` justifications are unchanged. `actionlint` clean (the only warnings are pre-existing SC2129 style notes in `go-release.yml`, unrelated to these lines).

## Follow-up

On merge, auto-tag will cut a patch release; the `featurebase-changelog-bot` caller will be re-pinned from `v2.12.0` to the new tag in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)